### PR TITLE
Point package main to dist file

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "react-geosuggest",
   "version": "1.2.0",
   "description": "A React autosuggest for the Google Maps Places API.",
-  "main": "src/Geosuggest.jsx",
+  "main": "dist/react-geosuggest.js",
   "author": "Robert Katzki <katzki@ubilabs.net>",
   "homepage": "https://github.com/ubilabs/react-geosuggest",
   "repository": {


### PR DESCRIPTION
By pointing the package `main` property to the built file, no transpile steps are necessary when pulling this component into a project.

This fixes issue https://github.com/ubilabs/react-geosuggest/issues/4