### PR TITLE
Create self-contained  module build

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,5 +1,8 @@
 var gulp = require('gulp'),
   git = require('gulp-git'),
+  rename = require('gulp-rename'),
+  gif = require('gulp-if'),
+  babel = require('gulp-babel'),
   initGulpTasks = require('react-component-gulp-tasks');
 
 
@@ -43,7 +46,15 @@ gulp.task('publish:tag', function(done) {
   });
 });
 
-gulp.task('release', ['bump', 'build', 'publish:tag', 'publish:npm', 'publish:examples']);
+gulp.task('build-module', function () {
+    return gulp.src('src/*.jsx')
+        .pipe(babel())
+        .pipe(rename({ extname: '.jsx' }))
+        .pipe(gif('**/Geosuggest.jsx', rename('index.js')))
+        .pipe(gulp.dest('dist/react-geosuggest.module'));
+});
+
+gulp.task('release', ['bump', 'build', 'build-module', 'publish:tag', 'publish:npm', 'publish:examples']);
 gulp.task('release:patch', ['release']);
-gulp.task('release:minor', ['bump:minor', 'build', 'publish:tag', 'publish:npm', 'publish:examples']);
-gulp.task('release:major', ['bump:major', 'build', 'publish:tag', 'publish:npm', 'publish:examples']);
+gulp.task('release:minor', ['bump:minor', 'build', 'build-module', 'publish:tag', 'publish:npm', 'publish:examples']);
+gulp.task('release:major', ['bump:major', 'build', 'build-module', 'publish:tag', 'publish:npm', 'publish:examples']);

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "react-geosuggest",
   "version": "1.2.3",
   "description": "A React autosuggest for the Google Maps Places API.",
-  "main": "dist/react-geosuggest.js",
+  "main": "dist/react-geosuggest.module",
   "author": "Robert Katzki <katzki@ubilabs.net>",
   "homepage": "https://github.com/ubilabs/react-geosuggest",
   "repository": {
@@ -18,7 +18,10 @@
   "devDependencies": {
     "eslint": "^0.24.0",
     "gulp": "^3.8.10",
+    "gulp-babel": "~5.1.0",
     "gulp-git": "^1.0.0",
+    "gulp-if": "~1.2.5",
+    "gulp-rename": "~1.2.2",
     "react-component-gulp-tasks": "^0.1.1",
     "reactify": "^1.1.0"
   },
@@ -33,7 +36,8 @@
   },
   "scripts": {
     "lint": "eslint ./src ./example/src",
-    "test": "npm run lint"
+    "test": "npm run lint",
+    "build": "gulp build && gulp build-module"
   },
   "readmeFilename": "README.md",
   "keywords": [


### PR DESCRIPTION
The previous PR, which aimed to fix requiring this component without a transpile step, was unsuccessful - https://github.com/ubilabs/react-geosuggest/pull/5

A transpiled, but non-packed distribution is required. The current distribution files include global variables  and wiring for use of `require` where it is not supported. This conflicts with a build system which supports require and not global variables.

The existing build has been set up solely for browserify output. This PR adds a new gulp task `build-module`, which uses `babel` to transpile the files into plain Javascript, but without packing the files together. These are output into the `react-geosuggest.module` directory within `dist` and the `package.json` has been updated to point to that directory. An `index.js` file is created as the entry point.