### PR TITLE
Houskeeping changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ As this component uses the Google Maps Places API to get suggests, you must incl
 
 The easiest way to use geosuggest is to install it from NPM and include it in your own React build process (using [Browserify](http://browserify.org), [Webpack](http://webpack.github.io/), etc).
 
-You can also use the standalone build by including `dist/geosuggest.js` in your page. If you use this, make sure you have already included React, and it is available as a global variable.
+You can also use the standalone build by including `dist/react-geosuggest.js` in your page. If you use this, make sure you have already included React, and it is available as a global variable.
 
 ```
 npm install react-geosuggest --save

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -43,7 +43,8 @@ gulp.task('publish:tag', function(done) {
   });
 });
 
-gulp.task('release', ['bump', 'build', 'publish:tag', 'publish:npm', 'publish:examples']);
+gulp.task('build-and-publish', ['build', 'publish:tag', 'publish:npm', 'publish:examples']);
+gulp.task('release', ['bump', 'build-and-publish']);
 gulp.task('release:patch', ['release']);
-gulp.task('release:minor', ['bump:minor', 'build', 'publish:tag', 'publish:npm', 'publish:examples']);
-gulp.task('release:major', ['bump:major', 'build', 'publish:tag', 'publish:npm', 'publish:examples']);
+gulp.task('release:minor', ['bump:minor', 'build-and-publish']);
+gulp.task('release:major', ['bump:major', 'build-and-publish']);

--- a/package.json
+++ b/package.json
@@ -34,7 +34,12 @@
   },
   "scripts": {
     "lint": "eslint ./src ./example/src",
-    "test": "npm run lint"
+    "test": "npm run lint",
+    "build": "gulp build",
+    "release": "gulp release",
+    "release:patch": "gulp release:patch",
+    "release:minor": "gulp release:minor",
+    "release:major": "gulp release:major"
   },
   "readmeFilename": "README.md",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "dist/react-geosuggest.js",
   "author": "Robert Katzki <katzki@ubilabs.net>",
   "homepage": "https://github.com/ubilabs/react-geosuggest",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/ubilabs/react-geosuggest.git"


### PR DESCRIPTION
This is a housekeeping PR which adds:

 - Correct typo in readme
 - Add license field to `package.json` to prevent warning on `npm install`
 - DRY gulp tasks by pushing common tasks into a separate named task
 - Add npm scripts entries for each of the gulp tasks so they can be called via `npm run x` without gulp globally installed.