### PR TITLE
Fixed node modules not working by removing jsx extensions in require.

### DIFF
--- a/example/src/app.js
+++ b/example/src/app.js
@@ -1,7 +1,7 @@
 /* global google */
 
 var React = require('react'),
-  Geosuggest = require('../../src/Geosuggest.jsx'); // eslint-disable-line
+  Geosuggest = require('../../src/Geosuggest'); // eslint-disable-line
 
 var App = React.createClass({ // eslint-disable-line
   /**

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "prepare:example": "rm -rf example/dist && mkdir example/dist && npm run copy:assets && npm run js:example && npm run css",
     "copy:assets": "cp example/src/*.html example/dist && cp example/src/*.svg example/dist",
     "css": "cat example/src/app.css src/geosuggest.css > example/dist/app.css",
-    "js:example": "browserify example/src/app.js -t babelify > example/dist/app.js",
+    "js:example": "browserify example/src/app.js -t babelify --extension=.jsx> example/dist/app.js",
     "js:example:uglify": "uglifyjs example/dist/app.js -o example/dist/app.js -c warnings=false,drop_console=true --mangle",
     "js:browser": "browserify src/Geosuggest.jsx --standalone Geosuggest --exclude react -t babelify --extension=.jsx > dist/react-geosuggest.js",
     "js:browser:uglify": "uglifyjs dist/react-geosuggest.js -o dist/react-geosuggest.min.js -c warnings=false,drop_console=true --mangle",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "css": "cat example/src/app.css src/geosuggest.css > example/dist/app.css",
     "js:example": "browserify example/src/app.js -t babelify > example/dist/app.js",
     "js:example:uglify": "uglifyjs example/dist/app.js -o example/dist/app.js -c warnings=false,drop_console=true --mangle",
-    "js:browser": "browserify src/Geosuggest.jsx --standalone Geosuggest --exclude react -t babelify > dist/react-geosuggest.js",
+    "js:browser": "browserify src/Geosuggest.jsx --standalone Geosuggest --exclude react -t babelify --extension=.jsx > dist/react-geosuggest.js",
     "js:browser:uglify": "uglifyjs dist/react-geosuggest.js -o dist/react-geosuggest.min.js -c warnings=false,drop_console=true --mangle",
     "build:module": "babel src --out-dir module",
     "build:browser": "npm run js:browser && npm run js:browser:uglify",

--- a/src/Geosuggest.jsx
+++ b/src/Geosuggest.jsx
@@ -1,7 +1,7 @@
 /* global google */
 
 var React = require('react'),
-  GeosuggestItem = require('./GeosuggestItem.jsx'); // eslint-disable-line
+  GeosuggestItem = require('./GeosuggestItem'); // eslint-disable-line
 
 var Geosuggest = React.createClass({
   /**


### PR DESCRIPTION
Added --extension=.jsx to browserify scripts in order to find those files. Babel automatically searches for those, but not browserify.
Fixes #16.