### PR TITLE
Support for server side rendering

### DIFF
--- a/src/Geosuggest.jsx
+++ b/src/Geosuggest.jsx
@@ -20,7 +20,6 @@ const Geosuggest = React.createClass({
       bounds: null,
       country: null,
       types: null,
-      googleMaps: google && google.maps,
       onSuggestSelect: () => {},
       onFocus: () => {},
       onBlur: () => {},
@@ -40,10 +39,7 @@ const Geosuggest = React.createClass({
       isSuggestsHidden: true,
       userInput: this.props.initialValue,
       activeSuggest: null,
-      suggests: [],
-      geocoder: new this.props.googleMaps.Geocoder(),
-      autocompleteService: new this.props.googleMaps.places
-        .AutocompleteService()
+      suggests: []
     };
   },
 
@@ -55,6 +51,27 @@ const Geosuggest = React.createClass({
     if (this.props.initialValue !== props.initialValue) {
       this.setState({userInput: props.initialValue});
     }
+  },
+
+  componentDidMount: function() {
+    this.setInputValue(this.props.initialValue);
+
+    var googleMap = (google && google.maps) || this.googleMaps;
+
+    if (!googleMap) {
+      console.error('Google map api was not found in the page.');
+    } else {
+      this.googleMaps = googleMap;
+    }
+
+    this.autocompleteService = new googleMap.places.AutocompleteService();
+    this.geocoder = new googleMap.Geocoder();
+  },
+
+  setInputValue: function(value) {
+    this.setState({
+      userInput: value
+    });
   },
 
   /**
@@ -106,7 +123,7 @@ const Geosuggest = React.createClass({
 
     var options = {
       input: this.state.userInput,
-      location: this.props.location || new this.props.googleMaps.LatLng(0, 0),
+      location: this.props.location || new this.googleMaps.LatLng(0, 0),
       radius: this.props.radius
     };
 
@@ -124,7 +141,7 @@ const Geosuggest = React.createClass({
       };
     }
 
-    this.state.autocompleteService.getPlacePredictions(
+    this.autocompleteService.getPlacePredictions(
       options,
       function(suggestsGoogle) {
         this.updateSuggests(suggestsGoogle);
@@ -277,10 +294,10 @@ const Geosuggest = React.createClass({
    * @param  {Object} suggest The suggest
    */
   geocodeSuggest: function(suggest) {
-    this.state.geocoder.geocode(
+    this.geocoder.geocode(
       {address: suggest.label},
       function(results, status) {
-        if (status !== this.props.googleMaps.GeocoderStatus.OK) {
+        if (status !== this.googleMaps.GeocoderStatus.OK) {
           return;
         }
 

--- a/src/Geosuggest.jsx
+++ b/src/Geosuggest.jsx
@@ -20,6 +20,7 @@ const Geosuggest = React.createClass({
       bounds: null,
       country: null,
       types: null,
+      googleMaps: null,
       onSuggestSelect: () => {},
       onFocus: () => {},
       onBlur: () => {},
@@ -53,21 +54,31 @@ const Geosuggest = React.createClass({
     }
   },
 
+  /**
+   * Called on the client side after component is mounted.
+   * Google api sdk object will be obtained and cached as a instance property.
+   * Necessary objects of google api will also be determined and saved.
+   */
   componentDidMount: function() {
     this.setInputValue(this.props.initialValue);
 
-    var googleMap = (google && google.maps) || this.googleMaps;
+    var googleMaps = this.props.googleMaps
+      || (google && google.maps) || this.googleMaps;
 
-    if (!googleMap) {
+    if (!googleMaps) {
       console.error('Google map api was not found in the page.');
     } else {
-      this.googleMaps = googleMap;
+      this.googleMaps = googleMaps;
     }
 
-    this.autocompleteService = new googleMap.places.AutocompleteService();
-    this.geocoder = new googleMap.Geocoder();
+    this.autocompleteService = new googleMaps.places.AutocompleteService();
+    this.geocoder = new googleMaps.Geocoder();
   },
 
+  /**
+   * Method used for setting initial value.
+   * @param {string} value to set in input
+   */
   setInputValue: function(value) {
     this.setState({
       userInput: value


### PR DESCRIPTION
This changes might already be there in https://github.com/ubilabs/react-geosuggest/pull/29, but since that included many other changes and is not merged.

Changes summary : 
1. googleMaps object moved out of props so that it can be set at client side in componentDidMount
2. Setting googleMaps and related objects in componentDidMount

I have tested this changes by building the changes and it works fine. 