### PR TITLE
Use labelId instead of address to get the geocode

### DIFF
--- a/src/Geosuggest.jsx
+++ b/src/Geosuggest.jsx
@@ -312,7 +312,7 @@ const Geosuggest = React.createClass({
    */
   geocodeSuggest: function(suggest) {
     this.geocoder.geocode(
-      {address: suggest.label},
+      {placeId: suggest.placeId},
       function(results, status) {
         if (status !== this.googleMaps.GeocoderStatus.OK) {
           return;


### PR DESCRIPTION
Searching for "Atlassian, George Street, Sydney, New South Wales, Australia" returns the following coordinates:

```
lat: -33.9547504
lng: 151.10536909999996
```

Searching the same thing on google map return the following coordinates:
```
lat: -33.8673329
lng: 151.20700339999996
```

Using placeId instead of label fixes this issue.