### PR TITLE
Add property for input class name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,12 @@ Default: `''`
 
 Add an additional class to the geosuggest container.
 
+#### inputClassName
+Type: `String`
+Default: `''`
+
+Add an additional class to the input.
+
 #### disabled
 Type: `Boolean`
 Default: `false`

--- a/src/Geosuggest.jsx
+++ b/src/Geosuggest.jsx
@@ -15,6 +15,7 @@ const Geosuggest = React.createClass({
       placeholder: 'Search places',
       disabled: false,
       className: '',
+      inputClassName: '',
       location: null,
       radius: null,
       bounds: null,
@@ -341,7 +342,7 @@ const Geosuggest = React.createClass({
       <div className={'geosuggest ' + this.props.className}
           onClick={this.onClick}>
         <input
-          className="geosuggest__input"
+          className={'geosuggest__input ' + this.props.inputClassName}
           ref="geosuggestInput"
           type="text"
           value={this.state.userInput}


### PR DESCRIPTION
There was some discussion on this in [8](https://github.com/ubilabs/react-geosuggest/issues/8), but for certain use cases it's really nice to be able to put a class on the input element. For example, using bootstrap to add a `form-control` class (when not using sass).