### PR TITLE
"use strict"; no longer throws errors if google cannot be loaded

### DIFF
--- a/src/Geosuggest.jsx
+++ b/src/Geosuggest.jsx
@@ -1,4 +1,4 @@
-/* global google */
+/* global window */
 
 import React from 'react';
 import GeosuggestItem from './GeosuggestItem'; // eslint-disable-line
@@ -63,13 +63,13 @@ const Geosuggest = React.createClass({
     this.setInputValue(this.props.initialValue);
 
     var googleMaps = this.props.googleMaps
-      || (google && google.maps) || this.googleMaps;
+      || (window.google && window.google.maps) || this.googleMaps;
 
     if (!googleMaps) {
       console.error('Google map api was not found in the page.');
-    } else {
-      this.googleMaps = googleMaps;
+      return;
     }
+    this.googleMaps = googleMaps;
 
     this.autocompleteService = new googleMaps.places.AutocompleteService();
     this.geocoder = new googleMaps.Geocoder();


### PR DESCRIPTION
Was working without internet and `google && google.maps` was causing an issue with `"use strict;"` (because the google namespace was not declared). Further, if the `googleMaps` var was falsely the component still tried to initialize.