### PR TITLE
Instantiate Google services in getInitialState instead

### DIFF
--- a/src/Geosuggest.jsx
+++ b/src/Geosuggest.jsx
@@ -38,6 +38,21 @@ const Geosuggest = React.createClass({
    * @return {Object} The state
    */
   getInitialState: function() {
+    var googleMaps = this.props.googleMaps ||
+      (window.google && // eslint-disable-line no-extra-parens
+      window.google.maps) ||
+      this.googleMaps;
+
+    if (!googleMaps) {
+      console.error(// eslint-disable-line no-console
+        'Google map api was not found in the page.');
+      return;
+    }
+    this.googleMaps = googleMaps;
+
+    this.autocompleteService = new googleMaps.places.AutocompleteService();
+    this.geocoder = new googleMaps.Geocoder();
+    
     return {
       isMounted: false,
       isSuggestsHidden: true,
@@ -64,22 +79,6 @@ const Geosuggest = React.createClass({
    */
   componentDidMount: function() {
     this.setInputValue(this.props.initialValue);
-
-    var googleMaps = this.props.googleMaps ||
-      (window.google && // eslint-disable-line no-extra-parens
-        window.google.maps) ||
-      this.googleMaps;
-
-    if (!googleMaps) {
-      console.error(// eslint-disable-line no-console
-        'Google map api was not found in the page.');
-      return;
-    }
-    this.googleMaps = googleMaps;
-
-    this.autocompleteService = new googleMaps.places.AutocompleteService();
-    this.geocoder = new googleMaps.Geocoder();
-
     this.setState({isMounted: true});
   },
 


### PR DESCRIPTION
I'm rendering `Geosuggest` based on some condition:

``` javascript
<div>
  {isOpen && <Geosuggest autoFocus/> || <SomethingElse/>}
</div>
```

the first time it mounts everything's fine, but the second time I get:

![screenshot from 2016-01-22 18 58 55](https://cloud.githubusercontent.com/assets/109238/12518769/c984182a-c13a-11e5-84dc-b225de94667b.png)

This PR is a possible fix
