### PR TITLE
Fix #60 - use ignoreBlur flag to avoid hiding suggests when clicking one

### DIFF
--- a/src/Geosuggest.jsx
+++ b/src/Geosuggest.jsx
@@ -99,6 +99,14 @@ const Geosuggest = React.createClass({
   },
 
   /**
+   * Flag so clicking a suggest is not treated as a blur
+   * @param {Boolean} ignore - whether blur events should be ignored
+   */
+  setIgnoreBlur: function(ignore) {
+    this.ignoreBlur = ignore;
+  },
+
+  /**
    * When the input got changed
    */
   onInputChange: function() {
@@ -116,6 +124,15 @@ const Geosuggest = React.createClass({
   onFocus: function() {
     this.props.onFocus();
     this.showSuggests();
+  },
+
+  /**
+   * When the input gets blurred
+   */
+  onBlur: function() {
+    if (!this.ignoreBlur) {
+      this.hideSuggests();
+    }
   },
 
   /**
@@ -312,6 +329,7 @@ const Geosuggest = React.createClass({
     });
 
     if (suggest.location) {
+      this.setIgnoreBlur(false);
       this.props.onSuggestSelect(suggest);
       return;
     }
@@ -370,7 +388,7 @@ const Geosuggest = React.createClass({
           onKeyDown={this.onInputKeyDown}
           onChange={this.onInputChange}
           onFocus={this.onFocus}
-          onBlur={this.hideSuggests} />
+          onBlur={this.onBlur} />
         <ul className={this.getSuggestsClasses()}>
           {this.getSuggestItems()}
         </ul>
@@ -392,6 +410,8 @@ const Geosuggest = React.createClass({
           key={suggest.placeId}
           suggest={suggest}
           isActive={isActive}
+          onMouseDown={() => this.setIgnoreBlur(true)}
+          onMouseOut={() => this.setIgnoreBlur(false)}
           onSuggestSelect={this.selectSuggest} />
       );
     }.bind(this));

--- a/src/GeosuggestItem.jsx
+++ b/src/GeosuggestItem.jsx
@@ -31,6 +31,8 @@ const GeosuggestItem = React.createClass({
   render: function() {
     return (// eslint-disable-line no-extra-parens
       <li className={this.getSuggestClasses()}
+        onMouseDown={this.props.onMouseDown}
+        onMouseOut={this.props.onMouseOut}
         onClick={this.onClick}>
           {this.props.suggest.label}
       </li>


### PR DESCRIPTION
Just implemented the `ignoreBlur` flag as done in [react-autocomplete](https://github.com/rackt/react-autocomplete/blob/master/lib/Autocomplete.js#L246), but added `onMouseOut` to restore the `ignoreBlur` flag.

The only piece this misses is if a user starts a `mousedown` on a suggestion, and releases the mouse outside of geosuggest. I think it'd be appropriate to use a one-time `mouseup` listener on `document.body` and respond based on it's target, but can see how that'd be debatable. Regardless, I think this is a worthwhile patch -- especially if you don't use the css transition when hiding the suggestions. May also be able to remove the 100ms timeout in `hideSuggests`.

Sidenote: I wanted to use this fork in my app, but since `.gitignore` ignores `module` and `.npmignore` ignores `src`, couldn't see how it could be done (other than perhaps `npm install <relative/path>`?), so I made a `master-pkg` branch and removed `module` from `.gitignore` -- is there something I'm missing?

Thanks for the library!