### PR TITLE
Escape user input for regex to avoid Exception

### DIFF
--- a/src/Geosuggest.jsx
+++ b/src/Geosuggest.jsx
@@ -4,6 +4,11 @@ import React from 'react';
 import GeosuggestItem from './GeosuggestItem'; // eslint-disable-line
 import inputAttributes from './input-attributes';
 
+// Escapes special characters in user input for regex
+function escapeRegExp(str) {
+  return str.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&');
+}
+
 const Geosuggest = React.createClass({
   /**
    * Get the default props
@@ -191,7 +196,7 @@ const Geosuggest = React.createClass({
     }
 
     var suggests = [],
-      regex = new RegExp(this.state.userInput, 'gim'),
+      regex = new RegExp(escapeRegExp(this.state.userInput), 'gim'),
       skipSuggest = this.props.skipSuggest;
 
     this.props.fixtures.forEach(suggest => {


### PR DESCRIPTION
Currently, if the user enters values with special characters, such as a "(" or ")", then an "unbalanced regex" exception is thrown and the search box breaks. This change makes sure to escape the user input string before passing it to the `new Regexp` constructor.