### PR TITLE
Handle null value for Google suggestions

### DIFF
--- a/src/Geosuggest.jsx
+++ b/src/Geosuggest.jsx
@@ -148,7 +148,7 @@ class Geosuggest extends React.Component {
     this.autocompleteService.getPlacePredictions(
       options,
       suggestsGoogle => {
-        this.updateSuggests(suggestsGoogle);
+        this.updateSuggests(suggestsGoogle || []); // can be null
 
         if (this.props.autoActivateFirstSuggest) {
           this.activateSuggest('next');


### PR DESCRIPTION
The `updateSuggests` function has an ES6 "default value" for the `suggestsGoogle` parameter, but this *only* works in the case of an `undefined` value (not `null`).

I've encountered a case where the `autocompleteService` actually returns `null` for  `suggestsGoogle`, and thus I get an error:

```
Uncaught TypeError: Cannot read property 'forEach' of null (Geosuggest.js:248)
 >  suggestsGoogle.forEach(function (suggest) {
```

This change handles the `null` case to make it less brittle :smile: 