### PR TITLE
Add className option for fixtures

### DIFF
--- a/src/suggest-list.jsx
+++ b/src/suggest-list.jsx
@@ -26,6 +26,7 @@ export default ({
         suggest.placeId === activeSuggest.placeId;
 
       return <SuggestItem key={suggest.placeId}
+        className={suggest.className}
         suggest={suggest}
         isActive={isActive}
         onMouseDown={onSuggestMouseDown}


### PR DESCRIPTION
In the docs you suggest you can pass a `className` key to fixtures yet you never carried it forward to the suggest object.