### PR TITLE
chore: update peer and dev dependencies for React v15

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/ubilabs/react-geosuggest/issues"
   },
   "peerDependencies": {
-    "react": "^0.14.0"
+    "react": "^0.14.0 || ^15.0.0"
   },
   "dependencies": {
     "classnames": "^2.2.3"
@@ -37,9 +37,9 @@
     "jsdom": "^8.1.0",
     "light-server": "^1.0.3",
     "mocha": "^2.4.5",
-    "react": "^0.14.0",
-    "react-addons-test-utils": "^0.14.7",
-    "react-dom": "^0.14.0",
+    "react": "^15.0.0",
+    "react-addons-test-utils": "^15.0.0",
+    "react-dom": "^15.0.0",
     "sinon": "^1.17.3",
     "uglifyjs": "^2.4.10"
   },


### PR DESCRIPTION
It seems to be able to update for React v15 with no pain. :grinning: 

Fix #119 