### PR TITLE
Bug fix for IE 10, 'this' is not defined in the constructor function.…

### DIFF
--- a/src/Geosuggest.jsx
+++ b/src/Geosuggest.jsx
@@ -27,7 +27,7 @@ class Geosuggest extends React.Component {
     super(props);
     this.state = {
       isSuggestsHidden: true,
-      userInput: this.props.initialValue,
+      userInput: props.initialValue,
       activeSuggest: null,
       suggests: [],
       timer: null


### PR DESCRIPTION
…  We need to access the props directly from the argument.