### PR TITLE
feat(Geosuggest): add onActivateSuggest event

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,15 @@ Gets triggered when a suggest got selected. Only parameter is an object with dat
 * `location` – Type `Object` – The location containing `lat` and `lng`
 * `gmaps` – Type `Object` – *Optional!* The complete response when there was a Google Maps geocode necessary (e.g. no location provided for presets). [Check the Google Maps Reference](https://developers.google.com/maps/documentation/javascript/reference#GeocoderResult) for more information on it’s structure.
 
+#### onActivateSuggest
+Type: `Function`
+Default: `function(suggest) {}`
+
+Gets triggered when a suggest is activated in the list. Only parameter is an object with data of the selected suggest. This data is available:
+
+* `label` – Type `String` – The label name
+* `placeId` – Type `String` – If it is a preset, equals the `label`. Else it is the Google Maps `placeID`
+
 #### getSuggestLabel
 Type: `Function`
 Default: `function(suggest) { return suggest.description; }`

--- a/src/Geosuggest.jsx
+++ b/src/Geosuggest.jsx
@@ -249,6 +249,8 @@ class Geosuggest extends React.Component {
       newActiveSuggest = this.state.suggests[newIndex];
     }
 
+    this.props.onActivateSuggest(newActiveSuggest);
+
     this.setState({activeSuggest: newActiveSuggest});
   }
 

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -14,6 +14,7 @@ export default {
   country: null,
   types: null,
   googleMaps: null,
+  onActivateSuggest: () => {},
   onSuggestSelect: () => {},
   onFocus: () => {},
   onBlur: () => {},

--- a/test/Geosuggest_spec.jsx
+++ b/test/Geosuggest_spec.jsx
@@ -38,16 +38,23 @@ window.google = global.google = {
 
 describe('Component: Geosuggest', () => {
 
-  let component, onSuggestSelect, isLocationCalled;
+  let component,
+    onSuggestSelect,
+    onActivateSuggest,
+    isLocationCalled,
+    isActivateCalled;
 
   beforeEach(() => {
     isLocationCalled = false;
+    isActivateCalled = false;
     onSuggestSelect = () => isLocationCalled = true;
+    onActivateSuggest = () => isActivateCalled = true;
 
     component = TestUtils.renderIntoDocument(
       <Geosuggest
         radius="20"
         onSuggestSelect={onSuggestSelect}
+        onActivateSuggest={onActivateSuggest}
       />
     );
   });
@@ -67,7 +74,15 @@ describe('Component: Geosuggest', () => {
     TestUtils.Simulate.keyDown(geoSuggestInput, {key: "keyDown", keyCode: 40, which: 40});
     TestUtils.Simulate.keyDown(geoSuggestInput, {key: "Enter", keyCode: 13, which: 13});
     expect(isLocationCalled).to.be.true;
+  });
 
+  it('should call `onActivateSuggest` when we key down to a suggestion', () => {
+    const input = component.refs.input;
+    const geoSuggestInput = TestUtils.findRenderedDOMComponentWithClass(component, 'geosuggest__input');
+    input.value = 'New';
+    TestUtils.Simulate.change(geoSuggestInput);
+    TestUtils.Simulate.keyDown(geoSuggestInput, {key: "keyDown", keyCode: 40, which: 40});
+    expect(isActivateCalled).to.be.true;
   });
 
 });


### PR DESCRIPTION
I need to hook into the event that takes place when a new suggestion is activated, so I created an `onActivateSuggest` event prop. Tell me what you think.