### PR TITLE
feat(Geosuggest): Add `debounce` prop, default to 250ms

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,13 @@ Default: `google.maps`
 
 In case you want to provide your own Google Maps object, pass it in as googleMaps. The default is the global google maps object.
 
+#### debounce
+Type: `Number`
+Default: `250`
+
+Sets the delay in milliseconds after typing before a request will be sent to find suggestions.
+Specify `0` if you wish to fetch suggestions after every keystroke.
+
 #### onFocus
 Type: `Function`
 Default: `function() {}`

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "react": "^0.14.0 || ^15.0.0"
   },
   "dependencies": {
-    "classnames": "^2.2.3"
+    "classnames": "^2.2.3",
+    "lodash": "^4.13.1"
   },
   "devDependencies": {
     "babel-cli": "^6.6.5",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "classnames": "^2.2.3",
-    "lodash": "^4.13.1"
+    "lodash.debounce": "^4.0.6"
   },
   "devDependencies": {
     "babel-cli": "^6.6.5",

--- a/src/Geosuggest.jsx
+++ b/src/Geosuggest.jsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import classnames from 'classnames';
+import {debounce} from 'lodash';
 
 import defaults from './defaults';
 import propTypes from './prop-types';
@@ -32,6 +33,14 @@ class Geosuggest extends React.Component {
       suggests: [],
       timer: null
     };
+
+    this.onInputChange = this.onInputChange.bind(this);
+    this.onAfterInputChange = this.onAfterInputChange.bind(this);
+
+    if (props.debounce) {
+      this.onAfterInputChange =
+        debounce(this.onAfterInputChange, props.debounce);
+    }
   }
 
   /**
@@ -78,10 +87,12 @@ class Geosuggest extends React.Component {
    * @param {String} userInput The input value of the user
    */
   onInputChange(userInput) {
-    this.setState({userInput}, () => {
-      this.showSuggests();
-      this.props.onChange(userInput);
-    });
+    this.setState({userInput}, this.onAfterInputChange);
+  }
+
+  onAfterInputChange() {
+    this.showSuggests();
+    this.props.onChange(this.state.userInput);
   }
 
   /**
@@ -319,7 +330,7 @@ class Geosuggest extends React.Component {
       input = <Input className={this.props.inputClassName}
         ref='input'
         value={this.state.userInput}
-        onChange={this.onInputChange.bind(this)}
+        onChange={this.onInputChange}
         onFocus={this.onInputFocus.bind(this)}
         onBlur={this.onInputBlur.bind(this)}
         style={this.props.style.input}

--- a/src/Geosuggest.jsx
+++ b/src/Geosuggest.jsx
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import classnames from 'classnames';
-import {debounce} from 'lodash';
+import debounce from 'lodash.debounce';
 
 import defaults from './defaults';
 import propTypes from './prop-types';

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -13,6 +13,7 @@ export default {
   bounds: null,
   country: null,
   types: null,
+  debounce: 250,
   googleMaps: null,
   onActivateSuggest: () => {},
   onSuggestSelect: () => {},

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -18,6 +18,7 @@ export default {
   bounds: React.PropTypes.object,
   country: React.PropTypes.string,
   types: React.PropTypes.array,
+  debounce: React.PropTypes.number,
   googleMaps: React.PropTypes.object,
   onSuggestSelect: React.PropTypes.func,
   onFocus: React.PropTypes.func,

--- a/test/Geosuggest_spec.jsx
+++ b/test/Geosuggest_spec.jsx
@@ -55,6 +55,7 @@ describe('Component: Geosuggest', () => {
         radius='20'
         onSuggestSelect={onSuggestSelect}
         onActivateSuggest={onActivateSuggest}
+        debounce={0}
         onChange={onChange}
         onFocus={onFocus}
         onBlur={onBlur}


### PR DESCRIPTION
I'm implementing debounce in a similar manner to Issue #131, with a default delay of 250ms.  The current implementation is actually unusable on IE11 because the cost in time to re-render on every keystroke causes the browser to eat keystrokes while you are typing.  Adding a debounce makes the component at least functional.