### PR TITLE
refactor(Geosuggest): Refactor out inline binds in JSX, fix IE11 perf

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -2,5 +2,6 @@
   "presets": [
     "es2015",
     "react"
-  ]
+  ],
+  "plugins": ["transform-class-properties"]
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -90,7 +90,6 @@
       "string": true
     }],
     "no-implied-eval": 2,
-    "no-invalid-this": 2,
     "no-iterator": 2,
     "no-labels": 2,
     "no-lone-blocks": 2,
@@ -235,6 +234,7 @@
     "no-const-assign": 2,
     "prefer-reflect": 1,
     "prefer-spread": 1,
-    "require-yield": 2
+    "require-yield": 2,
+    "react/jsx-no-bind": 2
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "babel-cli": "^6.6.5",
     "babel-core": "^6.7.0",
     "babel-eslint": "^4.1.8",
+    "babel-plugin-transform-class-properties": "^6.9.0",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.5.0",
     "babelify": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   },
   "dependencies": {
     "classnames": "^2.2.3",
-    "lodash.debounce": "^4.0.6"
+    "lodash.debounce": "^4.0.6",
+    "react-addons-shallow-compare": "^15.1.0"
   },
   "devDependencies": {
     "babel-cli": "^6.6.5",
@@ -40,9 +41,9 @@
     "light-server": "^1.0.3",
     "mocha": "^2.4.5",
     "nyc": "^6.4.4",
-    "react": "^15.0.0",
-    "react-addons-test-utils": "^15.0.0",
-    "react-dom": "^15.0.0",
+    "react": "^15.1.0",
+    "react-addons-test-utils": "^15.1.0",
+    "react-dom": "^15.1.0",
     "sinon": "^1.17.3",
     "uglifyjs": "^2.4.10"
   },

--- a/src/Geosuggest.jsx
+++ b/src/Geosuggest.jsx
@@ -86,11 +86,11 @@ class Geosuggest extends React.Component {
    * When the input got changed
    * @param {String} userInput The input value of the user
    */
-  onInputChange(userInput) {
+  onInputChange = userInput => {
     this.setState({userInput}, this.onAfterInputChange);
   }
 
-  onAfterInputChange() {
+  onAfterInputChange = () => {
     this.showSuggests();
     this.props.onChange(this.state.userInput);
   }
@@ -98,7 +98,7 @@ class Geosuggest extends React.Component {
   /**
    * When the input gets focused
    */
-  onInputFocus() {
+  onInputFocus = () => {
     this.props.onFocus();
     this.showSuggests();
   }
@@ -106,11 +106,21 @@ class Geosuggest extends React.Component {
   /**
    * When the input gets blurred
    */
-  onInputBlur() {
+  onInputBlur = () => {
     if (!this.state.ignoreBlur) {
       this.hideSuggests();
     }
   }
+
+  onNext = () => this.activateSuggest('next')
+
+  onPrev = () => this.activateSuggest('prev')
+
+  onSelect = () => this.selectSuggest(this.state.activeSuggest)
+
+  onSuggestMouseDown = () => this.setState({ignoreBlur: true})
+
+  onSuggestMouseOut = () => this.setState({ignoreBlur: false})
 
   /**
    * Focus the input
@@ -132,7 +142,7 @@ class Geosuggest extends React.Component {
    * Clear the input and close the suggestion pane
    */
   clear() {
-    this.setState({userInput: ''}, () => this.hideSuggests());
+    this.setState({userInput: ''}, this.hideSuggests);
   }
 
   /**
@@ -221,7 +231,7 @@ class Geosuggest extends React.Component {
   /**
    * Hide the suggestions
    */
-  hideSuggests() {
+  hideSuggests = () => {
     this.props.onBlur(this.state.userInput);
     const timer = setTimeout(() => {
       this.setState({isSuggestsHidden: true});
@@ -269,7 +279,7 @@ class Geosuggest extends React.Component {
    * When an item got selected
    * @param {GeosuggestItem} suggest The selected suggest item
    */
-  selectSuggest(suggest) {
+  selectSuggest = suggest => {
     if (!suggest) {
       suggest = {
         label: this.state.userInput
@@ -331,22 +341,21 @@ class Geosuggest extends React.Component {
         ref='input'
         value={this.state.userInput}
         ignoreTab={this.props.ignoreTab}
-        onChange={this.onInputChange}
-        onFocus={this.onInputFocus.bind(this)}
-        onBlur={this.onInputBlur.bind(this)}
         style={this.props.style.input}
-        onNext={() => this.activateSuggest('next')}
-        onPrev={() => this.activateSuggest('prev')}
-        onSelect={() => this.selectSuggest(this.state.activeSuggest)}
-        onEscape={this.hideSuggests.bind(this)} {...attributes} />,
+        onChange={this.onInputChange}
+        onFocus={this.onInputFocus}
+        onBlur={this.onInputBlur}
+        onNext={this.onNext}
+        onPrev={this.onPrev}
+        onSelect={this.onSelect}
+        onEscape={this.hideSuggests} {...attributes} />,
       suggestionsList = <SuggestList isHidden={this.state.isSuggestsHidden}
         style={this.props.style.suggests}
-        suggestItemStyle={this.props.style.suggestItem}
         suggests={this.state.suggests}
         activeSuggest={this.state.activeSuggest}
-        onSuggestMouseDown={() => this.setState({ignoreBlur: true})}
-        onSuggestMouseOut={() => this.setState({ignoreBlur: false})}
-        onSuggestSelect={this.selectSuggest.bind(this)}/>;
+        onSuggestMouseDown={this.onSuggestMouseDown}
+        onSuggestMouseOut={this.onSuggestMouseOut}
+        onSuggestSelect={this.selectSuggest}/>;
 
     return <div className={classes}>
       <div className="geosuggest__input-wrapper">

--- a/src/Geosuggest.jsx
+++ b/src/Geosuggest.jsx
@@ -351,6 +351,7 @@ class Geosuggest extends React.Component {
         onEscape={this.hideSuggests} {...attributes} />,
       suggestionsList = <SuggestList isHidden={this.state.isSuggestsHidden}
         style={this.props.style.suggests}
+        suggestItemStyle={this.props.style.suggestItem}
         suggests={this.state.suggests}
         activeSuggest={this.state.activeSuggest}
         onSuggestMouseDown={this.onSuggestMouseDown}

--- a/src/input.jsx
+++ b/src/input.jsx
@@ -1,4 +1,5 @@
 import React from 'react'; // eslint-disable-line no-unused-vars
+import shallowCompare from 'react-addons-shallow-compare';
 import classnames from 'classnames';
 
 import filterInputAttributes from './filter-input-attributes';
@@ -9,6 +10,9 @@ import filterInputAttributes from './filter-input-attributes';
  * @return {JSX} The icon component.
  */
 class Input extends React.Component {
+  shouldComponentUpdate(nextProps, nextState) {
+    return shallowCompare(this, nextProps, nextState);
+  }
   /**
    * When the input got changed
    */

--- a/src/input.jsx
+++ b/src/input.jsx
@@ -12,15 +12,23 @@ class Input extends React.Component {
   /**
    * When the input got changed
    */
-  onChange() {
+  onChange = () => {
     this.props.onChange(this.refs.input.value);
+  }
+
+  onFocus = () => {
+    this.props.onFocus();
+  }
+
+  onBlur = () => {
+    this.props.onBlur();
   }
 
   /**
    * When a key gets pressed in the input
    * @param  {Event} event The keypress event
    */
-  onInputKeyDown(event) {
+  onInputKeyDown = event => {
     switch (event.which) {
       case 40: // DOWN
         event.preventDefault();
@@ -72,10 +80,10 @@ class Input extends React.Component {
       {...attributes}
       value={this.props.value}
       style={this.props.style}
-      onKeyDown={this.onInputKeyDown.bind(this)}
-      onChange={this.onChange.bind(this)}
-      onFocus={this.props.onFocus.bind(this)}
-      onBlur={this.props.onBlur.bind(this)} />;
+      onKeyDown={this.onInputKeyDown}
+      onChange={this.onChange}
+      onFocus={this.onFocus}
+      onBlur={this.onBlur} />;
   }
 }
 
@@ -86,14 +94,7 @@ class Input extends React.Component {
 Input.defaultProps = {
   className: '',
   value: '',
-  ignoreTab: false,
-  onChange: () => {},
-  onFocus: () => {},
-  onBlur: () => {},
-  onNext: () => {},
-  onPrev: () => {},
-  onSelect: () => {},
-  onEscape: () => {}
+  ignoreTab: false
 };
 
 export default Input;

--- a/src/suggest-item.jsx
+++ b/src/suggest-item.jsx
@@ -1,4 +1,4 @@
-import React from 'react'; // eslint-disable-line no-unused-vars
+import React from 'react';
 import classnames from 'classnames';
 
 /**
@@ -6,29 +6,31 @@ import classnames from 'classnames';
  * @param {Object} props The component's props
  * @return {JSX} The icon component.
  */
-export default ({
-  isActive = false,
-  className = '',
-  suggest = {},
-  onMouseDown = () => {},
-  onMouseOut = () => {},
-  onSelect = () => {},
-  style = {}
-}) => {
-  const classes = classnames(
-    'geosuggest-item',
-    className,
-    {'geosuggest-item--active': isActive}
-  );
+export default class SuggestItem extends React.Component {
+  onClick = event => {
+    event.preventDefault();
+    this.props.onSelect(this.props.suggest);
+  }
 
-  return <li className={classes}
-    style={style}
-    onMouseDown={onMouseDown}
-    onMouseOut={onMouseOut}
-    onClick={event => {
-      event.preventDefault();
-      onSelect();
-    }}>
-      {suggest.label}
-  </li>;
+  render() {
+    const classes = classnames(
+      'geosuggest-item',
+      this.props.className,
+      {'geosuggest-item--active': this.props.isActive}
+    );
+
+    return <li className={classes}
+      style={this.props.style}
+      onMouseDown={this.props.onMouseDown}
+      onMouseOut={this.props.onMouseOut}
+      onClick={this.onClick}>
+        {this.props.suggest.label}
+    </li>;
+  }
+}
+
+SuggestItem.defaultProps = {
+  isActive: false,
+  className: '',
+  suggest: {}
 };

--- a/src/suggest-item.jsx
+++ b/src/suggest-item.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import shallowCompare from 'react-addons-shallow-compare';
 import classnames from 'classnames';
 
 /**
@@ -7,6 +8,10 @@ import classnames from 'classnames';
  * @return {JSX} The icon component.
  */
 export default class SuggestItem extends React.Component {
+  shouldComponentUpdate(nextProps, nextState) {
+    return shallowCompare(this, nextProps, nextState);
+  }
+
   onClick = event => {
     event.preventDefault();
     this.props.onSelect(this.props.suggest);

--- a/src/suggest-list.jsx
+++ b/src/suggest-list.jsx
@@ -1,4 +1,5 @@
 import React from 'react'; // eslint-disable-line no-unused-vars
+import shallowCompare from 'react-addons-shallow-compare';
 import classnames from 'classnames';
 import SuggestItem from './suggest-item';
 
@@ -8,6 +9,10 @@ import SuggestItem from './suggest-item';
  * @return {JSX} The icon component.
  */
 export default class SuggestList extends React.Component {
+  shouldComponentUpdate(nextProps, nextState) {
+    return shallowCompare(this, nextProps, nextState);
+  }
+
   isHidden() {
     return this.props.isHidden || this.props.suggests.length === 0;
   }

--- a/src/suggest-list.jsx
+++ b/src/suggest-list.jsx
@@ -7,33 +7,36 @@ import SuggestItem from './suggest-item';
  * @param {Object} props The component's props
  * @return {JSX} The icon component.
  */
-export default ({
-  isHidden = true,
-  suggests = [],
-  activeSuggest,
-  onSuggestMouseDown = () => {},
-  onSuggestMouseOut = () => {},
-  onSuggestSelect = () => {},
-  style = {},
-  suggestItemStyle = {}
-}) => {
-  const classes = classnames(
-    'geosuggest__suggests',
-    {'geosuggest__suggests--hidden': isHidden || suggests.length === 0}
-  );
-  return <ul className={classes} style={style}>
-    {suggests.map(suggest => {
-      const isActive = activeSuggest &&
-        suggest.placeId === activeSuggest.placeId;
+export default class SuggestList extends React.Component {
+  isHidden() {
+    return this.props.isHidden || this.props.suggests.length === 0;
+  }
 
-      return <SuggestItem key={suggest.placeId}
-        className={suggest.className}
-        suggest={suggest}
-        style={suggestItemStyle}
-        isActive={isActive}
-        onMouseDown={onSuggestMouseDown}
-        onMouseOut={onSuggestMouseOut}
-        onSelect={() => onSuggestSelect(suggest)} />;
-    })}
-  </ul>;
+  render() {
+    const classes = classnames(
+      'geosuggest__suggests',
+      {'geosuggest__suggests--hidden': this.isHidden()}
+    );
+
+    return <ul className={classes} style={this.props.style}>
+      {this.props.suggests.map(suggest => {
+        const isActive = this.props.activeSuggest &&
+          suggest.placeId === this.props.activeSuggest.placeId;
+
+        return <SuggestItem key={suggest.placeId}
+          className={suggest.className}
+          suggest={suggest}
+          style={this.props.suggestItemStyle}
+          isActive={isActive}
+          onMouseDown={this.props.onSuggestMouseDown}
+          onMouseOut={this.props.onSuggestMouseOut}
+          onSelect={this.props.onSuggestSelect} />;
+      })}
+    </ul>;
+  }
+}
+
+SuggestList.defaultProps = {
+  isHidden: true,
+  suggests: []
 };


### PR DESCRIPTION
Using bind or fat arrows inside of JSX is bad for performance in a number of ways, since it creates new functions on every render. (See https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-bind.md for more details of the problem)

I've refactored the existing components to no longer using inline bindings, but instead to be bound as class properties, an ES proposal supported by Babel.

This builds on top of PR #134 