### PR TITLE
fix(Geosuggest): Set autoComplete='off' and remove autoComplete option

### DIFF
--- a/src/Geosuggest.jsx
+++ b/src/Geosuggest.jsx
@@ -315,6 +315,7 @@ class Geosuggest extends React.Component {
       );
     var input = <Input className={this.props.inputClassName}
                  ref='input'
+                 autoComplete='off'
                  value={this.state.userInput}
                  onChange={this.onInputChange.bind(this)}
                  onFocus={this.onInputFocus.bind(this)}

--- a/src/filter-input-attributes.js
+++ b/src/filter-input-attributes.js
@@ -2,7 +2,6 @@
  * Attributes allowed on input elements
  */
 const allowedAttributes = [
-  'autoComplete',
   'autoFocus',
   'disabled',
   'form',


### PR DESCRIPTION
fixes #136

Some browsers display the default auto complete box on top of the suggestion list if a `name` attribute is set on the Geosuggest element.
I can't think of a situation were having autoComplete enabled would be desirable.
Removing the option and setting it to 'off' by default seems reasonable.