### PR TITLE
(fix): GeoCode fixtures when no location is provided

### DIFF
--- a/src/Geosuggest.jsx
+++ b/src/Geosuggest.jsx
@@ -180,7 +180,6 @@ class Geosuggest extends React.Component {
       if (!skipSuggest(suggest) && suggest.label.match(regex)) {
         fixturesSearched++;
 
-        suggest.placeId = suggest.label;
         suggests.push(suggest);
       }
     });
@@ -270,6 +269,7 @@ class Geosuggest extends React.Component {
 
     if (suggest.location) {
       this.setState({ignoreBlur: false});
+      suggest.placeId = suggest.placeId || suggest.label;
       this.props.onSuggestSelect(suggest);
       return;
     }
@@ -292,6 +292,7 @@ class Geosuggest extends React.Component {
         var gmaps = results[0],
           location = gmaps.geometry.location;
 
+        suggest.placeId = suggest.placeId || gmaps.place_id;
         suggest.gmaps = gmaps;
         suggest.location = {
           lat: location.lat(),

--- a/src/suggest-list.jsx
+++ b/src/suggest-list.jsx
@@ -21,11 +21,11 @@ export default ({
   );
 
   return <ul className={classes}>
-    {suggests.map(suggest => {
+    {suggests.map((suggest, index) => {
       const isActive = activeSuggest &&
         suggest.placeId === activeSuggest.placeId;
 
-      return <SuggestItem key={suggest.placeId}
+      return <SuggestItem key={index}
         className={suggest.className}
         suggest={suggest}
         isActive={isActive}


### PR DESCRIPTION
According to the readme, it is possible to pass fixtures without a location.
If this happens, the fixtures will be automatically geocoded using the label.
This was previously not working. Fixtures without a location attribute were added to the list, but the `onSuggestSelect` event never fired for these fixtures.
This happened because the placeId of fixtures was always set to their label. The GeoCoding function noticed that a placeId was present, and attempted to GeoCode the fixture using the placeId. This PR updates the code to only set the placeId to the label if no GeoCoding is required.