### PR TITLE
fix(Geosuggest): Hide the suggest list when the result set is empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,17 @@ Default: `''`
 
 Add an additional class to the geosuggest container.
 
+#### style
+Type: `Object`
+Default: `{
+  'input': {},
+  'suggests': {},
+  'suggestItem': {}
+}`
+
+Add an additional style to `Geosuggest`.
+This would support overriding/adding styles to the input suggestList and suggestItem.
+
 #### inputClassName
 Type: `String`
 Default: `''`
@@ -139,7 +150,7 @@ Gets triggered when the input field receives focus.
 
 #### onBlur
 Type: `Function`
-Default: `function() {}`
+Default: `function(value) {}`
 
 Gets triggered when input field loses focus.
 

--- a/src/geosuggest.css
+++ b/src/geosuggest.css
@@ -39,7 +39,8 @@
   -webkit-transition: max-height 0.2s, border 0.2s;
           transition: max-height 0.2s, border 0.2s;
 }
-.geosuggest__suggests--hidden {
+.geosuggest__suggests--hidden,
+.geosuggest__suggests:empty {
   max-height: 0;
   overflow: hidden;
   border-width: 0;

--- a/src/geosuggest.css
+++ b/src/geosuggest.css
@@ -39,8 +39,7 @@
   -webkit-transition: max-height 0.2s, border 0.2s;
           transition: max-height 0.2s, border 0.2s;
 }
-.geosuggest__suggests--hidden,
-.geosuggest__suggests:empty {
+.geosuggest__suggests--hidden {
   max-height: 0;
   overflow: hidden;
   border-width: 0;

--- a/src/suggest-list.jsx
+++ b/src/suggest-list.jsx
@@ -19,7 +19,7 @@ export default ({
 }) => {
   const classes = classnames(
     'geosuggest__suggests',
-    {'geosuggest__suggests--hidden': isHidden}
+    {'geosuggest__suggests--hidden': isHidden || suggests.length === 0}
   );
   return <ul className={classes} style={style}>
     {suggests.map(suggest => {

--- a/test/Geosuggest_spec.jsx
+++ b/test/Geosuggest_spec.jsx
@@ -39,8 +39,8 @@ describe('Component: Geosuggest', () => {
   let component = null,
     onSuggestSelect = null,
     onActivateSuggest = null,
-    isLocationCalled = false,
-    isActivateCalled = false;
+    isLocationCalled, // eslint-disable-line init-declarations
+    isActivateCalled; // eslint-disable-line init-declarations
 
   beforeEach(() => {
     isLocationCalled = false;
@@ -118,5 +118,17 @@ describe('Component: Geosuggest', () => {
   it('should add external inline `style` to suggestList component', () => { // eslint-disable-line max-len
     const geoSuggestList = TestUtils.findRenderedDOMComponentWithClass(component, 'geosuggest__suggests'); // eslint-disable-line max-len
     expect(geoSuggestList.style['border-color']).to.be.equal('#000');
+  });
+
+  it('should hide the suggestion box when there are no suggestions', () => {
+    const input = component.refs.input,
+      geoSuggestInput = TestUtils.findRenderedDOMComponentWithClass(component, 'geosuggest__input'), // eslint-disable-line max-len
+      geoSuggestList = TestUtils.findRenderedDOMComponentWithClass(component, 'geosuggest__suggests'), // eslint-disable-line max-len
+      classList = geoSuggestList.classList;
+
+    input.value = 'There is no result for this. Really.';
+    TestUtils.Simulate.change(geoSuggestInput);
+
+    expect(classList.contains('geosuggest__suggests--hidden')).to.be.true; // eslint-disable-line max-len, no-unused-expressions
   });
 });


### PR DESCRIPTION
This fixes a small design bug which was visible when removing focus from the search box while the result set was empty.