### PR TITLE
fix(Geosuggest): Reset activeSuggest when necessary

### DIFF
--- a/src/Geosuggest.jsx
+++ b/src/Geosuggest.jsx
@@ -171,7 +171,7 @@ class Geosuggest extends React.Component {
       skipSuggest = this.props.skipSuggest,
       maxFixtures = 10,
       fixturesSearched = 0,
-      activeSuggest = this.state.activeSuggest;
+      activeSuggest = null;
 
     this.props.fixtures.forEach(suggest => {
       if (fixturesSearched >= maxFixtures) {
@@ -197,7 +197,18 @@ class Geosuggest extends React.Component {
       }
     });
 
-    // check if activeSuggest is still in list
+    activeSuggest = this.updateActiveSuggest(suggests);
+    this.setState({suggests, activeSuggest});
+  }
+
+  /**
+   * Return the new activeSuggest object after suggests have been updated
+   * @param {Array} suggests The new list of suggests
+   * @return {Object} The new activeSuggest
+   **/
+  updateActiveSuggest(suggests = []) {
+    let activeSuggest = this.state.activeSuggest;
+
     if (activeSuggest) {
       const newSuggest = suggests.find(listedSuggest =>
         activeSuggest.placeId === listedSuggest.placeId &&
@@ -207,7 +218,7 @@ class Geosuggest extends React.Component {
       activeSuggest = newSuggest || null;
     }
 
-    this.setState({suggests, activeSuggest});
+    return activeSuggest;
   }
 
   /**

--- a/src/Geosuggest.jsx
+++ b/src/Geosuggest.jsx
@@ -170,7 +170,8 @@ class Geosuggest extends React.Component {
       regex = new RegExp(escapeRegExp(this.state.userInput), 'gim'),
       skipSuggest = this.props.skipSuggest,
       maxFixtures = 10,
-      fixturesSearched = 0;
+      fixturesSearched = 0,
+      activeSuggest = this.state.activeSuggest;
 
     this.props.fixtures.forEach(suggest => {
       if (fixturesSearched >= maxFixtures) {
@@ -196,7 +197,17 @@ class Geosuggest extends React.Component {
       }
     });
 
-    this.setState({suggests});
+    // check if activeSuggest is still in list
+    if (activeSuggest) {
+      const newSuggest = suggests.find(listedSuggest =>
+        activeSuggest.placeId === listedSuggest.placeId &&
+        activeSuggest.isFixture === listedSuggest.isFixture
+      );
+
+      activeSuggest = newSuggest || null;
+    }
+
+    this.setState({suggests, activeSuggest});
   }
 
   /**
@@ -213,7 +224,10 @@ class Geosuggest extends React.Component {
   hideSuggests() {
     this.props.onBlur(this.state.userInput);
     const timer = setTimeout(() => {
-      this.setState({isSuggestsHidden: true});
+      this.setState({
+        isSuggestsHidden: true,
+        activeSuggest: null
+      });
     }, 100);
 
     this.setState({timer});


### PR DESCRIPTION
This PR fixes a bug where the wrong suggestion was selected under the following circumstances:

* Input field was selected
* User entered some text
* A suggestion was selected using the arrow keys
* The input text was changed so that the new suggestion list did not contain the last selected suggestion anymore
* A new suggest was **NOT** selected using the arrow keys after changing the input
* The user pressed `tab` or `enter`