### PR TITLE
feat(Geosuggest): Option to ignore tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,12 @@ Default: `google.maps`
 
 In case you want to provide your own Google Maps object, pass it in as googleMaps. The default is the global google maps object.
 
+#### ignoreTab
+Type: `Boolean`
+Default: `false`
+
+When the tab key is pressed, the `onSelect` handler is invoked. Set to true to not invoke `onSelect` on tab press.
+
 #### onFocus
 Type: `Function`
 Default: `function() {}`

--- a/src/Geosuggest.jsx
+++ b/src/Geosuggest.jsx
@@ -319,6 +319,7 @@ class Geosuggest extends React.Component {
       input = <Input className={this.props.inputClassName}
         ref='input'
         value={this.state.userInput}
+        ignoreTab={this.props.ignoreTab}
         onChange={this.onInputChange.bind(this)}
         onFocus={this.onInputFocus.bind(this)}
         onBlur={this.onInputBlur.bind(this)}

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -26,5 +26,6 @@ export default {
     'input': {},
     'suggests': {},
     'suggestItem': {}
-  }
+  },
+  ignoreTab: false
 };

--- a/src/input.jsx
+++ b/src/input.jsx
@@ -35,7 +35,9 @@ class Input extends React.Component {
         this.props.onSelect();
         break;
       case 9: // TAB
-        this.props.onSelect();
+        if (!this.props.ignoreTab) {
+          this.props.onSelect();
+        }
         break;
       case 27: // ESC
         this.props.onEscape();
@@ -84,6 +86,7 @@ class Input extends React.Component {
 Input.defaultProps = {
   className: '',
   value: '',
+  ignoreTab: false,
   onChange: () => {},
   onFocus: () => {},
   onBlur: () => {},

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -30,5 +30,6 @@ export default {
     input: React.PropTypes.object,
     suggests: React.PropTypes.object,
     suggestItem: React.PropTypes.object
-  })
+  }),
+  ignoreTab: React.PropTypes.bool
 };

--- a/test/Geosuggest_spec.jsx
+++ b/test/Geosuggest_spec.jsx
@@ -171,4 +171,28 @@ describe('Component: Geosuggest', () => {
 
     expect(classList.contains('geosuggest__suggests--hidden')).to.be.true; // eslint-disable-line max-len, no-unused-expressions
   });
+
+  it('should call onSuggestSelect on enter', () => {
+    const input = component.refs.input,
+      geoSuggestInput = TestUtils.findRenderedDOMComponentWithClass(component, 'geosuggest__input'); // eslint-disable-line max-len
+    input.value = 'New';
+    TestUtils.Simulate.keyDown(geoSuggestInput, {
+      key: 'Enter',
+      keyCode: 13,
+      which: 13
+    });
+    expect(onSuggestSelect.calledOnce).to.be.true; // eslint-disable-line no-unused-expressions, max-len
+  });
+
+  it('should call onSuggestSelect on tab', () => {
+    const input = component.refs.input,
+      geoSuggestInput = TestUtils.findRenderedDOMComponentWithClass(component, 'geosuggest__input'); // eslint-disable-line max-len
+    input.value = 'New';
+    TestUtils.Simulate.keyDown(geoSuggestInput, {
+      key: 'Tab',
+      keyCode: 9,
+      which: 9
+    });
+    expect(onSuggestSelect.calledOnce).to.be.true; // eslint-disable-line no-unused-expressions, max-len
+  });
 });

--- a/test/Geosuggest_spec.jsx
+++ b/test/Geosuggest_spec.jsx
@@ -41,38 +41,40 @@ describe('Component: Geosuggest', () => {
     onActivateSuggest = null,
     onFocus = null,
     onChange = null,
-    onBlur = null;
+    onBlur = null,
+    render = props => {
+      onSuggestSelect = sinon.spy();
+      onActivateSuggest = sinon.spy();
+      onChange = sinon.spy();
+      onFocus = sinon.spy();
+      onBlur = sinon.spy();
 
-  beforeEach(() => {
-    onSuggestSelect = sinon.spy();
-    onActivateSuggest = sinon.spy();
-    onChange = sinon.spy();
-    onFocus = sinon.spy();
-    onBlur = sinon.spy();
+      component = TestUtils.renderIntoDocument(
+        <Geosuggest
+          radius='20'
+          onSuggestSelect={onSuggestSelect}
+          onActivateSuggest={onActivateSuggest}
+          onChange={onChange}
+          onFocus={onFocus}
+          onBlur={onBlur}
+          style={{
+            'input': {
+              'borderColor': '#000'
+            },
+            'suggests': {
+              'borderColor': '#000'
+            },
+            'suggestItem': {
+              'borderColor': '#000',
+              'borderWidth': 1
+            }
+          }}
+          {...props}
+        />
+      );
+    };
 
-    component = TestUtils.renderIntoDocument(
-      <Geosuggest
-        radius='20'
-        onSuggestSelect={onSuggestSelect}
-        onActivateSuggest={onActivateSuggest}
-        onChange={onChange}
-        onFocus={onFocus}
-        onBlur={onBlur}
-        style={{
-          'input': {
-            'borderColor': '#000'
-          },
-          'suggests': {
-            'borderColor': '#000'
-          },
-          'suggestItem': {
-            'borderColor': '#000',
-            'borderWidth': 1
-          }
-        }}
-      />
-    );
-  });
+  beforeEach(() => render());
 
   it('should have an input field', () => {
     const input = TestUtils.scryRenderedDOMComponentsWithClass(component, 'geosuggest__input'); // eslint-disable-line max-len

--- a/test/Geosuggest_spec.jsx
+++ b/test/Geosuggest_spec.jsx
@@ -74,127 +74,145 @@ describe('Component: Geosuggest', () => {
       );
     };
 
-  beforeEach(() => render());
+  describe('default', () => {
+    beforeEach(() => render());
 
-  it('should have an input field', () => {
-    const input = TestUtils.scryRenderedDOMComponentsWithClass(component, 'geosuggest__input'); // eslint-disable-line max-len
-    expect(input).to.have.lengthOf(1);
-  });
-
-  it('should call `onSuggestSelect` when we type a city name and choose some of the suggestions', () => { // eslint-disable-line max-len
-    const input = component.refs.input,
-      geoSuggestInput = TestUtils.findRenderedDOMComponentWithClass(component, 'geosuggest__input'); // eslint-disable-line max-len
-    input.value = 'New';
-    TestUtils.Simulate.change(geoSuggestInput);
-    TestUtils.Simulate.keyDown(geoSuggestInput, {
-      key: 'keyDown',
-      keyCode: 40,
-      which: 40
+    it('should have an input field', () => {
+      const input = TestUtils.scryRenderedDOMComponentsWithClass(component, 'geosuggest__input'); // eslint-disable-line max-len
+      expect(input).to.have.lengthOf(1);
     });
-    TestUtils.Simulate.keyDown(geoSuggestInput, {
-      key: 'keyDown',
-      keyCode: 40,
-      which: 40
+
+    it('should call `onSuggestSelect` when we type a city name and choose some of the suggestions', () => { // eslint-disable-line max-len
+      const input = component.refs.input,
+        geoSuggestInput = TestUtils.findRenderedDOMComponentWithClass(component, 'geosuggest__input'); // eslint-disable-line max-len
+      input.value = 'New';
+      TestUtils.Simulate.change(geoSuggestInput);
+      TestUtils.Simulate.keyDown(geoSuggestInput, {
+        key: 'keyDown',
+        keyCode: 40,
+        which: 40
+      });
+      TestUtils.Simulate.keyDown(geoSuggestInput, {
+        key: 'keyDown',
+        keyCode: 40,
+        which: 40
+      });
+      TestUtils.Simulate.keyDown(geoSuggestInput, {
+        key: 'Enter',
+        keyCode: 13,
+        which: 13
+      });
+      expect(onSuggestSelect.calledOnce).to.be.true; // eslint-disable-line no-unused-expressions, max-len
     });
-    TestUtils.Simulate.keyDown(geoSuggestInput, {
-      key: 'Enter',
-      keyCode: 13,
-      which: 13
+
+    it('should call `onActivateSuggest` when we key down to a suggestion', () => { // eslint-disable-line max-len
+      const input = component.refs.input,
+        geoSuggestInput = TestUtils.findRenderedDOMComponentWithClass(component, 'geosuggest__input'); // eslint-disable-line max-len
+      input.value = 'New';
+      TestUtils.Simulate.change(geoSuggestInput);
+      TestUtils.Simulate.keyDown(geoSuggestInput, {
+        key: 'keyDown',
+        keyCode: 40,
+        which: 40
+      });
+      expect(onActivateSuggest.calledOnce).to.be.true; // eslint-disable-line no-unused-expressions, max-len
     });
-    expect(onSuggestSelect.calledOnce).to.be.true; // eslint-disable-line no-unused-expressions, max-len
-  });
 
-  it('should call `onActivateSuggest` when we key down to a suggestion', () => { // eslint-disable-line max-len
-    const input = component.refs.input,
-      geoSuggestInput = TestUtils.findRenderedDOMComponentWithClass(component, 'geosuggest__input'); // eslint-disable-line max-len
-    input.value = 'New';
-    TestUtils.Simulate.change(geoSuggestInput);
-    TestUtils.Simulate.keyDown(geoSuggestInput, {
-      key: 'keyDown',
-      keyCode: 40,
-      which: 40
+    it('should call `onFocus` when we focus the input', () => {
+      const geoSuggestInput = TestUtils.findRenderedDOMComponentWithClass(component, 'geosuggest__input'); // eslint-disable-line max-len
+      TestUtils.Simulate.focus(geoSuggestInput);
+      expect(onFocus.calledOnce).to.be.true; // eslint-disable-line no-unused-expressions, max-len
     });
-    expect(onActivateSuggest.calledOnce).to.be.true; // eslint-disable-line no-unused-expressions, max-len
-  });
 
-  it('should call `onFocus` when we focus the input', () => {
-    const geoSuggestInput = TestUtils.findRenderedDOMComponentWithClass(component, 'geosuggest__input'); // eslint-disable-line max-len
-    TestUtils.Simulate.focus(geoSuggestInput);
-    expect(onFocus.calledOnce).to.be.true; // eslint-disable-line no-unused-expressions, max-len
-  });
-
-  it('should call `onBlur` when we remove the focus from the input', () => {
-    const geoSuggestInput = TestUtils.findRenderedDOMComponentWithClass(component, 'geosuggest__input'); // eslint-disable-line max-len
-    TestUtils.Simulate.focus(geoSuggestInput);
-    geoSuggestInput.value = 'New';
-    TestUtils.Simulate.change(geoSuggestInput);
-    TestUtils.Simulate.blur(geoSuggestInput);
-    expect(onBlur.withArgs('New').calledOnce).to.be.true; // eslint-disable-line no-unused-expressions, max-len
-  });
-
-  it('should call `onChange` when we change the input value', () => {
-    const geoSuggestInput = TestUtils.findRenderedDOMComponentWithClass(component, 'geosuggest__input'); // eslint-disable-line max-len
-    geoSuggestInput.value = 'New';
-    TestUtils.Simulate.change(geoSuggestInput);
-    expect(onChange.withArgs('New').calledOnce).to.be.true; // eslint-disable-line no-unused-expressions, max-len
-  });
-
-  it('should call `onChange` when the update method is called', () => {
-    component.update('New');
-    expect(onChange.withArgs('New').calledOnce).to.be.true; // eslint-disable-line no-unused-expressions, max-len
-  });
-
-  it('should clear the input text when calling `clear`', () => {
-    const geoSuggestInput = TestUtils.findRenderedDOMComponentWithClass(component, 'geosuggest__input'); // eslint-disable-line max-len
-    geoSuggestInput.value = 'New';
-    TestUtils.Simulate.change(geoSuggestInput);
-    component.clear();
-    expect(geoSuggestInput.value).to.equal('');
-  });
-
-  it('should add external inline `style` to input component', () => { // eslint-disable-line max-len
-    const geoSuggestInput = TestUtils.findRenderedDOMComponentWithClass(component, 'geosuggest__input'); // eslint-disable-line max-len
-    expect(geoSuggestInput.style['border-color']).to.be.equal('#000');
-  });
-
-  it('should add external inline `style` to suggestList component', () => { // eslint-disable-line max-len
-    const geoSuggestList = TestUtils.findRenderedDOMComponentWithClass(component, 'geosuggest__suggests'); // eslint-disable-line max-len
-    expect(geoSuggestList.style['border-color']).to.be.equal('#000');
-  });
-
-  it('should hide the suggestion box when there are no suggestions', () => {
-    const input = component.refs.input,
-      geoSuggestInput = TestUtils.findRenderedDOMComponentWithClass(component, 'geosuggest__input'), // eslint-disable-line max-len
-      geoSuggestList = TestUtils.findRenderedDOMComponentWithClass(component, 'geosuggest__suggests'), // eslint-disable-line max-len
-      classList = geoSuggestList.classList;
-
-    input.value = 'There is no result for this. Really.';
-    TestUtils.Simulate.change(geoSuggestInput);
-
-    expect(classList.contains('geosuggest__suggests--hidden')).to.be.true; // eslint-disable-line max-len, no-unused-expressions
-  });
-
-  it('should call onSuggestSelect on enter', () => {
-    const input = component.refs.input,
-      geoSuggestInput = TestUtils.findRenderedDOMComponentWithClass(component, 'geosuggest__input'); // eslint-disable-line max-len
-    input.value = 'New';
-    TestUtils.Simulate.keyDown(geoSuggestInput, {
-      key: 'Enter',
-      keyCode: 13,
-      which: 13
+    it('should call `onBlur` when we remove the focus from the input', () => {
+      const geoSuggestInput = TestUtils.findRenderedDOMComponentWithClass(component, 'geosuggest__input'); // eslint-disable-line max-len
+      TestUtils.Simulate.focus(geoSuggestInput);
+      geoSuggestInput.value = 'New';
+      TestUtils.Simulate.change(geoSuggestInput);
+      TestUtils.Simulate.blur(geoSuggestInput);
+      expect(onBlur.withArgs('New').calledOnce).to.be.true; // eslint-disable-line no-unused-expressions, max-len
     });
-    expect(onSuggestSelect.calledOnce).to.be.true; // eslint-disable-line no-unused-expressions, max-len
+
+    it('should call `onChange` when we change the input value', () => {
+      const geoSuggestInput = TestUtils.findRenderedDOMComponentWithClass(component, 'geosuggest__input'); // eslint-disable-line max-len
+      geoSuggestInput.value = 'New';
+      TestUtils.Simulate.change(geoSuggestInput);
+      expect(onChange.withArgs('New').calledOnce).to.be.true; // eslint-disable-line no-unused-expressions, max-len
+    });
+
+    it('should call `onChange` when the update method is called', () => {
+      component.update('New');
+      expect(onChange.withArgs('New').calledOnce).to.be.true; // eslint-disable-line no-unused-expressions, max-len
+    });
+
+    it('should clear the input text when calling `clear`', () => {
+      const geoSuggestInput = TestUtils.findRenderedDOMComponentWithClass(component, 'geosuggest__input'); // eslint-disable-line max-len
+      geoSuggestInput.value = 'New';
+      TestUtils.Simulate.change(geoSuggestInput);
+      component.clear();
+      expect(geoSuggestInput.value).to.equal('');
+    });
+
+    it('should add external inline `style` to input component', () => { // eslint-disable-line max-len
+      const geoSuggestInput = TestUtils.findRenderedDOMComponentWithClass(component, 'geosuggest__input'); // eslint-disable-line max-len
+      expect(geoSuggestInput.style['border-color']).to.be.equal('#000');
+    });
+
+    it('should add external inline `style` to suggestList component', () => { // eslint-disable-line max-len
+      const geoSuggestList = TestUtils.findRenderedDOMComponentWithClass(component, 'geosuggest__suggests'); // eslint-disable-line max-len
+      expect(geoSuggestList.style['border-color']).to.be.equal('#000');
+    });
+
+    it('should hide the suggestion box when there are no suggestions', () => {
+      const input = component.refs.input,
+        geoSuggestInput = TestUtils.findRenderedDOMComponentWithClass(component, 'geosuggest__input'), // eslint-disable-line max-len
+        geoSuggestList = TestUtils.findRenderedDOMComponentWithClass(component, 'geosuggest__suggests'), // eslint-disable-line max-len
+        classList = geoSuggestList.classList;
+
+      input.value = 'There is no result for this. Really.';
+      TestUtils.Simulate.change(geoSuggestInput);
+
+      expect(classList.contains('geosuggest__suggests--hidden')).to.be.true; // eslint-disable-line max-len, no-unused-expressions
+    });
+
+    it('should call onSuggestSelect on enter', () => {
+      const input = component.refs.input,
+        geoSuggestInput = TestUtils.findRenderedDOMComponentWithClass(component, 'geosuggest__input'); // eslint-disable-line max-len
+      input.value = 'New';
+      TestUtils.Simulate.keyDown(geoSuggestInput, {
+        key: 'Enter',
+        keyCode: 13,
+        which: 13
+      });
+      expect(onSuggestSelect.calledOnce).to.be.true; // eslint-disable-line no-unused-expressions, max-len
+    });
+
+    it('should call onSuggestSelect on tab', () => {
+      const input = component.refs.input,
+        geoSuggestInput = TestUtils.findRenderedDOMComponentWithClass(component, 'geosuggest__input'); // eslint-disable-line max-len
+      input.value = 'New';
+      TestUtils.Simulate.keyDown(geoSuggestInput, {
+        key: 'Tab',
+        keyCode: 9,
+        which: 9
+      });
+      expect(onSuggestSelect.calledOnce).to.be.true; // eslint-disable-line no-unused-expressions, max-len
+    });
   });
 
-  it('should call onSuggestSelect on tab', () => {
-    const input = component.refs.input,
-      geoSuggestInput = TestUtils.findRenderedDOMComponentWithClass(component, 'geosuggest__input'); // eslint-disable-line max-len
-    input.value = 'New';
-    TestUtils.Simulate.keyDown(geoSuggestInput, {
-      key: 'Tab',
-      keyCode: 9,
-      which: 9
+  describe('with tab ignored', () => {
+    beforeEach(() => render({ignoreTab: true}));
+
+    it('should not call onSuggestSelect on tab', () => {
+      const input = component.refs.input,
+        geoSuggestInput = TestUtils.findRenderedDOMComponentWithClass(component, 'geosuggest__input'); // eslint-disable-line max-len
+      input.value = 'New';
+      TestUtils.Simulate.keyDown(geoSuggestInput, {
+        key: 'Tab',
+        keyCode: 9,
+        which: 9
+      });
+      expect(onSuggestSelect.calledOnce).to.be.false; // eslint-disable-line no-unused-expressions, max-len
     });
-    expect(onSuggestSelect.calledOnce).to.be.true; // eslint-disable-line no-unused-expressions, max-len
   });
 });


### PR DESCRIPTION
The current behavior of Geosuggest is to trigger `onSelect` when the tab key is pressed in the input field. This PR adds an optional `ignoreTab` property to Geosuggest to disable that behavior. The default behavior is the same as before.