### PR TITLE
feat(Geosuggest): Add 'queryDelay' parameter with a default of 250ms

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,13 @@ Default: `false`
 
 When the tab key is pressed, the `onSelect` handler is invoked. Set to true to not invoke `onSelect` on tab press.
 
+#### queryDelay
+Type: `Number`
+Default: `250`
+
+Sets the delay in milliseconds after typing before a request will be sent to find suggestions.
+Specify `0` if you wish to fetch suggestions after every keystroke.
+
 #### onFocus
 Type: `Function`
 Default: `function() {}`

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "react": "^0.14.0 || ^15.0.0"
   },
   "dependencies": {
-    "classnames": "^2.2.3"
+    "classnames": "^2.2.3",
+    "lodash.debounce": "^4.0.6"
   },
   "devDependencies": {
     "babel-cli": "^6.6.5",

--- a/src/Geosuggest.jsx
+++ b/src/Geosuggest.jsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import classnames from 'classnames';
+import debounce from 'lodash.debounce';
 
 import defaults from './defaults';
 import propTypes from './prop-types';
@@ -32,6 +33,14 @@ class Geosuggest extends React.Component {
       suggests: [],
       timer: null
     };
+
+    this.onInputChange = this.onInputChange.bind(this);
+    this.onAfterInputChange = this.onAfterInputChange.bind(this);
+
+    if (props.queryDelay) {
+      this.onAfterInputChange =
+        debounce(this.onAfterInputChange, props.queryDelay);
+    }
   }
 
   /**
@@ -78,10 +87,12 @@ class Geosuggest extends React.Component {
    * @param {String} userInput The input value of the user
    */
   onInputChange(userInput) {
-    this.setState({userInput}, () => {
-      this.showSuggests();
-      this.props.onChange(userInput);
-    });
+    this.setState({userInput}, this.onAfterInputChange);
+  }
+
+  onAfterInputChange() {
+    this.showSuggests();
+    this.props.onChange(this.state.userInput);
   }
 
   /**
@@ -320,7 +331,7 @@ class Geosuggest extends React.Component {
         ref='input'
         value={this.state.userInput}
         ignoreTab={this.props.ignoreTab}
-        onChange={this.onInputChange.bind(this)}
+        onChange={this.onInputChange}
         onFocus={this.onInputFocus.bind(this)}
         onBlur={this.onInputBlur.bind(this)}
         style={this.props.style.input}

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -13,6 +13,7 @@ export default {
   bounds: null,
   country: null,
   types: null,
+  queryDelay: 250,
   googleMaps: null,
   onActivateSuggest: () => {},
   onSuggestSelect: () => {},

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -18,6 +18,7 @@ export default {
   bounds: React.PropTypes.object,
   country: React.PropTypes.string,
   types: React.PropTypes.array,
+  queryDelay: React.PropTypes.number,
   googleMaps: React.PropTypes.object,
   onSuggestSelect: React.PropTypes.func,
   onFocus: React.PropTypes.func,

--- a/test/Geosuggest_spec.jsx
+++ b/test/Geosuggest_spec.jsx
@@ -52,6 +52,7 @@ describe('Component: Geosuggest', () => {
       component = TestUtils.renderIntoDocument(
         <Geosuggest
           radius='20'
+          queryDelay={0}
           onSuggestSelect={onSuggestSelect}
           onActivateSuggest={onActivateSuggest}
           onChange={onChange}


### PR DESCRIPTION
I'm implementing debounce in a similar manner to Issue #131, with a default delay of 250ms.