### PR TITLE
fix(Geosuggest): fix `autoActivateFirstSuggest` prop

### DIFF
--- a/src/Geosuggest.jsx
+++ b/src/Geosuggest.jsx
@@ -174,20 +174,23 @@ class Geosuggest extends React.Component {
     this.autocompleteService.getPlacePredictions(
       options,
       suggestsGoogle => {
-        this.updateSuggests(suggestsGoogle || []); // can be null
-
-        if (this.props.autoActivateFirstSuggest) {
-          this.activateSuggest('next');
-        }
+        this.updateSuggests(suggestsGoogle || [], // can be null
+          () => {
+            if (this.props.autoActivateFirstSuggest &&
+              !this.state.activeSuggest) {
+              this.activateSuggest('next');
+            }
+          });
       }
     );
   }
 
   /**
    * Update the suggests
-   * @param  {Array} suggestsGoogle The new google suggests
+   * @param {Array} suggestsGoogle The new google suggests
+   * @param {Function} callback Called once the state has been updated
    */
-  updateSuggests(suggestsGoogle = []) {
+  updateSuggests(suggestsGoogle = [], callback) {
     var suggests = [],
       regex = new RegExp(escapeRegExp(this.state.userInput), 'gim'),
       skipSuggest = this.props.skipSuggest,
@@ -220,7 +223,7 @@ class Geosuggest extends React.Component {
     });
 
     activeSuggest = this.updateActiveSuggest(suggests);
-    this.setState({suggests, activeSuggest});
+    this.setState({suggests, activeSuggest}, callback);
   }
 
   /**

--- a/src/Geosuggest.jsx
+++ b/src/Geosuggest.jsx
@@ -177,7 +177,8 @@ class Geosuggest extends React.Component {
         this.updateSuggests(suggestsGoogle || [], // can be null
           () => {
             if (this.props.autoActivateFirstSuggest &&
-              !this.state.activeSuggest) {
+              !this.state.activeSuggest
+            ) {
               this.activateSuggest('next');
             }
           });

--- a/test/Geosuggest_spec.jsx
+++ b/test/Geosuggest_spec.jsx
@@ -358,4 +358,48 @@ describe('Component: Geosuggest', () => {
       expect(suggest.classList.contains('geosuggest__suggests--hidden')).to.be.false; // eslint-disable-line no-unused-expressions, max-len
     });
   });
+
+  describe('with autoActivateFirstSuggest enabled', () => {
+    const props = {
+      autoActivateFirstSuggest: true
+    };
+
+    beforeEach(() => render(props));
+
+    it('should not activate a suggest before focus', () => {
+      const activeItems = TestUtils.scryRenderedDOMComponentsWithClass(component, 'geosuggest-item--active'); // eslint-disable-line max-len
+      expect(activeItems.length).to.be.equal(0);
+      expect(onActivateSuggest.called).to.be.false; // eslint-disable-line no-unused-expressions, max-len
+    });
+
+    it('should call `onActivateSuggest` when auto-activating the first suggest', () => { // eslint-disable-line max-len
+      const geoSuggestInput = TestUtils.findRenderedDOMComponentWithClass(component, 'geosuggest__input'); // eslint-disable-line max-len
+      geoSuggestInput.value = 'New';
+      TestUtils.Simulate.change(geoSuggestInput);
+
+      expect(onActivateSuggest.calledOnce).to.be.true; // eslint-disable-line no-unused-expressions, max-len
+    });
+
+    it('should not change the active suggest when it is set already', () => {
+      const geoSuggestInput = TestUtils.findRenderedDOMComponentWithClass(component, 'geosuggest__input'); // eslint-disable-line max-len
+      geoSuggestInput.value = 'New';
+      TestUtils.Simulate.change(geoSuggestInput);
+      geoSuggestInput.value = 'New York';
+      TestUtils.Simulate.change(geoSuggestInput);
+
+      expect(onActivateSuggest.calledOnce).to.be.true; // eslint-disable-line no-unused-expressions, max-len
+    });
+
+    it('should activate a suggest once there is some input', done => {
+      const geoSuggestInput = TestUtils.findRenderedDOMComponentWithClass(component, 'geosuggest__input'); // eslint-disable-line max-len
+      geoSuggestInput.value = 'New';
+      TestUtils.Simulate.change(geoSuggestInput);
+
+      setImmediate(() => {
+        const activeItems = TestUtils.scryRenderedDOMComponentsWithClass(component, 'geosuggest-item--active'); // eslint-disable-line max-len
+        expect(activeItems.length).to.be.equal(1);
+        done();
+      });
+    });
+  });
 });


### PR DESCRIPTION
<!-- Please fill out the title field according to our commit conventions -->

### Description

This PR fixes two bugs which occur when the `autoActivateFirstSuggest` prop is enabled:

* The activeSuggest continuously wanders down the suggest list while typing a location name
* The activeSuggest is not auto selected in some cases, as `activateSuggest('next')` might be called before the state has finished updating

### Checklist

<!-- Mark these as checked by replacing [ ] with [x] -->
- [x] All tests passing
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
- [x] Commits and PR follow conventions
