### PR TITLE
fix(Geosuggest): allow enter key events to propagate if suggestions are hidden

### DIFF
--- a/src/Geosuggest.jsx
+++ b/src/Geosuggest.jsx
@@ -386,6 +386,7 @@ class Geosuggest extends React.Component {
       input = <Input className={this.props.inputClassName}
         ref='input'
         value={this.state.userInput}
+        ignoreEnter={!this.state.isSuggestsHidden}
         ignoreTab={this.props.ignoreTab}
         style={this.props.style.input}
         onChange={this.onInputChange}

--- a/src/input.jsx
+++ b/src/input.jsx
@@ -56,7 +56,10 @@ class Input extends React.Component {
         this.props.onPrev();
         break;
       case 13: // ENTER
-        event.preventDefault();
+        if (this.props.ignoreEnter) {
+          event.preventDefault();
+        }
+
         this.props.onSelect();
         break;
       case 9: // TAB


### PR DESCRIPTION
### Description

Fixes a bug where forms could not be submitted even when suggestions were hidden, as described in #184.

### Checklist

<!-- Mark these as checked by replacing [ ] with [x] -->
- [x] All tests passing
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
- [x] Commits and PR follow conventions