### PR TITLE
Adding props suggestsClassName and suggestItemsClassName

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,20 @@ Default: `''`
 
 Add an additional class to the input.
 
+#### suggestListClassName
+Type: `String`
+Default: `''`
+
+Add an additional class to suggest list.
+
+#### suggestItemClassName
+Type: `String`
+Default: `''`
+
+Add an additional class to suggest items.
+
+
+
 #### disabled
 Type: `Boolean`
 Default: `false`

--- a/dist/react-geosuggest.js
+++ b/dist/react-geosuggest.js
@@ -58,7 +58,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  *
  * @typechecks
- * 
+ *
  */
 
 /*eslint-disable no-self-compare */
@@ -1103,6 +1103,8 @@ exports.default = {
   disabled: false,
   className: '',
   inputClassName: '',
+  suggestListClassName: '',
+  suggestItemClassName: '',
   location: null,
   radius: null,
   bounds: null,

--- a/src/Geosuggest.jsx
+++ b/src/Geosuggest.jsx
@@ -399,6 +399,8 @@ class Geosuggest extends React.Component {
       suggestionsList = <SuggestList isHidden={this.state.isSuggestsHidden}
         style={this.props.style.suggests}
         suggestItemStyle={this.props.style.suggestItem}
+        suggestsClassName={this.props.suggestsClassName}
+        suggestItemsClassName={this.props.suggestItemsClassName}
         suggests={this.state.suggests}
         activeSuggest={this.state.activeSuggest}
         onSuggestNoResults={this.onSuggestNoResults}

--- a/src/Geosuggest.jsx
+++ b/src/Geosuggest.jsx
@@ -399,8 +399,8 @@ class Geosuggest extends React.Component {
       suggestionsList = <SuggestList isHidden={this.state.isSuggestsHidden}
         style={this.props.style.suggests}
         suggestItemStyle={this.props.style.suggestItem}
-        suggestsClassName={this.props.suggestsClassName}
-        suggestItemsClassName={this.props.suggestItemsClassName}
+        suggestListClassName={this.props.suggestListClassName}
+        suggestItemClassName={this.props.suggestItemClassName}
         suggests={this.state.suggests}
         activeSuggest={this.state.activeSuggest}
         onSuggestNoResults={this.onSuggestNoResults}

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -10,6 +10,8 @@ export default {
   disabled: React.PropTypes.bool,
   className: React.PropTypes.string,
   inputClassName: React.PropTypes.string,
+  suggestsClassName: React.PropTypes.string,
+  suggestItemsClassName: React.PropTypes.string,
   location: React.PropTypes.object,
   radius: React.PropTypes.oneOfType([
     React.PropTypes.string,

--- a/src/suggest-item.jsx
+++ b/src/suggest-item.jsx
@@ -35,6 +35,7 @@ export default class SuggestItem extends React.Component {
     const classes = classnames(
       'geosuggest-item',
       this.props.className,
+      this.props.suggestItemsClassName,
       {'geosuggest-item--active': this.props.isActive}
     );
 

--- a/src/suggest-item.jsx
+++ b/src/suggest-item.jsx
@@ -35,7 +35,7 @@ export default class SuggestItem extends React.Component {
     const classes = classnames(
       'geosuggest-item',
       this.props.className,
-      this.props.suggestItemsClassName,
+      this.props.suggestItemClassName,
       {'geosuggest-item--active': this.props.isActive}
     );
 

--- a/src/suggest-list.jsx
+++ b/src/suggest-list.jsx
@@ -46,7 +46,7 @@ export default class SuggestList extends React.Component {
   render() {
     const classes = classnames(
       'geosuggest__suggests',
-      this.props.suggestsClassName,
+      this.props.suggestListClassName,
       {'geosuggest__suggests--hidden': this.isHidden()}
     );
 
@@ -59,7 +59,7 @@ export default class SuggestList extends React.Component {
           className={suggest.className}
           suggest={suggest}
           style={this.props.suggestItemStyle}
-          suggestItemsClassName={this.props.suggestItemsClassName}
+          suggestItemClassName={this.props.suggestItemClassName}
           isActive={isActive}
           onMouseDown={this.props.onSuggestMouseDown}
           onMouseOut={this.props.onSuggestMouseOut}

--- a/src/suggest-list.jsx
+++ b/src/suggest-list.jsx
@@ -46,6 +46,7 @@ export default class SuggestList extends React.Component {
   render() {
     const classes = classnames(
       'geosuggest__suggests',
+      this.props.suggestsClassName,
       {'geosuggest__suggests--hidden': this.isHidden()}
     );
 
@@ -58,6 +59,7 @@ export default class SuggestList extends React.Component {
           className={suggest.className}
           suggest={suggest}
           style={this.props.suggestItemStyle}
+          suggestItemsClassName={this.props.suggestItemsClassName}
           isActive={isActive}
           onMouseDown={this.props.onSuggestMouseDown}
           onMouseOut={this.props.onSuggestMouseOut}


### PR DESCRIPTION
Enabling react-geosuggest to receive: suggestsClassName and suggestItemsClassName as properties.

It is possible to pass the properties like the example below:

```
<Geosuggest
          fixtures={fixtures}
          onFocus={this.onFocus}
          onBlur={this.onBlur}
          onChange={this.onChange}
          suggestsClassName={'my__geosuggest__suggests'}
          suggestItemsClassName={'my_geosuggest-item'}
          onSuggestSelect={this.onSuggestSelect}
          onSuggestNoResults={this.onSuggestNoResults}
          location={new google.maps.LatLng(53.558572, 9.9278215)}
          radius="20" />

```
The classes my__geosuggest__suggests and my_geosuggest-item are passes by props to Geosuggest