### PR TITLE
fix(package): Specify addon as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,12 +14,12 @@
     "url": "https://github.com/ubilabs/react-geosuggest/issues"
   },
   "peerDependencies": {
-    "react": "^0.14.0 || ^15.0.0"
+    "react": "^0.14.0 || ^15.0.0",
+    "react-addons-shallow-compare": "^0.14.0 || ^15.0.0"
   },
   "dependencies": {
     "classnames": "^2.2.3",
-    "lodash.debounce": "^4.0.6",
-    "react-addons-shallow-compare": "^15.1.0"
+    "lodash.debounce": "^4.0.6"
   },
   "devDependencies": {
     "babel-cli": "^6.6.5",


### PR DESCRIPTION
<!-- Please fill out the title field according to our commit conventions -->

### Description

Fixes a bug where:

> npm WARN saveError peer invalid: react@^15.3.1, required by react-addons-shallow-compare@15.3.1

happened when running `npm install` and

> npm ERR! peer invalid: react@^15.3.1, required by react-addons-shallow-compare@15.3.1

happened when running `npm shrinkwrap`.

### Checklist

<!-- Mark these as checked by replacing [ ] with [x] -->
- [x] All tests passing
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
- [x] Commits and PR follow conventions

**BREAKING CHANGE:** react-addons-shallow-compare is now a peer dependency,
meaning users must install it separately from react-geosuggest.

The peer dependency for react allows one to use either react 0.14 or
0.15. However, the dependency for react-addons-shallow-compare only
allows 0.15 versions. For anyone using react 0.14 this causes warnings
from npm saying that the peer dependency for react 0.15 (specified by
react-addons-shallow-compare) is missing. This completely breaks
workflows depending on `npm shrinkwrap`.