### PR TITLE
fixes the bug #179, hides the suggest when input blurs

### DIFF
--- a/src/Geosuggest.jsx
+++ b/src/Geosuggest.jsx
@@ -100,7 +100,9 @@ class Geosuggest extends React.Component {
    * On After the input got changed
    */
   onAfterInputChange = () => {
-    this.showSuggests();
+    if (!this.state.isSuggestsHidden) {
+      this.showSuggests();
+    }
     this.props.onChange(this.state.userInput);
   }
 

--- a/src/input.jsx
+++ b/src/input.jsx
@@ -53,7 +53,7 @@ class Input extends React.Component {
    * When a key gets pressed in the input
    * @param  {Event} event The keydown event
    */
-  onInputKeyDown = event => {
+  onInputKeyDown = event => { // eslint-disable-line complexity
     switch (event.which) {
       case 40: // DOWN
         event.preventDefault();

--- a/test/Geosuggest_spec.jsx
+++ b/test/Geosuggest_spec.jsx
@@ -103,6 +103,7 @@ describe('Component: Geosuggest', () => {
       const geoSuggestInput = TestUtils.findRenderedDOMComponentWithClass(component, 'geosuggest__input'); // eslint-disable-line max-len
       geoSuggestInput.value = 'New';
       TestUtils.Simulate.change(geoSuggestInput);
+      TestUtils.Simulate.focus(geoSuggestInput);
 
       const suggestItems = TestUtils.scryRenderedDOMComponentsWithClass(component, 'geosuggest-item'); // eslint-disable-line max-len, one-var
       TestUtils.Simulate.click(suggestItems[0]);
@@ -113,6 +114,7 @@ describe('Component: Geosuggest', () => {
       const geoSuggestInput = TestUtils.findRenderedDOMComponentWithClass(component, 'geosuggest__input'); // eslint-disable-line max-len
       geoSuggestInput.value = 'New';
       TestUtils.Simulate.change(geoSuggestInput);
+      TestUtils.Simulate.focus(geoSuggestInput);
       TestUtils.Simulate.keyDown(geoSuggestInput, {
         key: 'keyDown',
         keyCode: 40,
@@ -166,6 +168,7 @@ describe('Component: Geosuggest', () => {
       const geoSuggestInput = TestUtils.findRenderedDOMComponentWithClass(component, 'geosuggest__input'); // eslint-disable-line max-len
       geoSuggestInput.value = 'Ne';
       TestUtils.Simulate.change(geoSuggestInput);
+      TestUtils.Simulate.focus(geoSuggestInput);
       TestUtils.Simulate.keyDown(geoSuggestInput, {
         key: 'keyDown',
         keyCode: 40,
@@ -223,6 +226,7 @@ describe('Component: Geosuggest', () => {
 
       geoSuggestInput.value = 'New';
       TestUtils.Simulate.change(geoSuggestInput);
+      TestUtils.Simulate.focus(geoSuggestInput);
       TestUtils.Simulate.keyDown(geoSuggestInput, {
         key: 'keyUp',
         keyCode: 38,
@@ -254,6 +258,7 @@ describe('Component: Geosuggest', () => {
       const geoSuggestInput = TestUtils.findRenderedDOMComponentWithClass(component, 'geosuggest__input'); // eslint-disable-line max-len
       geoSuggestInput.value = 'New';
       TestUtils.Simulate.change(geoSuggestInput);
+      TestUtils.Simulate.focus(geoSuggestInput);
 
       const geoSuggestItems = TestUtils.scryRenderedDOMComponentsWithClass(component, 'geosuggest-item'); // eslint-disable-line max-len, one-var
       expect(geoSuggestItems[0].style['border-color']).to.be.equal('#000');
@@ -275,6 +280,7 @@ describe('Component: Geosuggest', () => {
 
       input.value = 'There is no result for this. Really.';
       TestUtils.Simulate.change(geoSuggestInput);
+      TestUtils.Simulate.focus(geoSuggestInput);
 
       expect(onSuggestNoResults.calledOnce).to.be.true;  // eslint-disable-line max-len, no-unused-expressions
     });
@@ -341,6 +347,7 @@ describe('Component: Geosuggest', () => {
 
       geoSuggestInput.value = 'Rio';
       TestUtils.Simulate.change(geoSuggestInput);
+      TestUtils.Simulate.focus(geoSuggestInput);
 
       const suggests = TestUtils.scryRenderedDOMComponentsWithClass(component, 'geosuggest-item'); // eslint-disable-line max-len, one-var
       expect(suggests.length).to.be.equal(1);
@@ -398,6 +405,7 @@ describe('Component: Geosuggest', () => {
       const geoSuggestInput = TestUtils.findRenderedDOMComponentWithClass(component, 'geosuggest__input'); // eslint-disable-line max-len
       geoSuggestInput.value = 'New';
       TestUtils.Simulate.change(geoSuggestInput);
+      TestUtils.Simulate.focus(geoSuggestInput);
 
       expect(onActivateSuggest.calledOnce).to.be.true; // eslint-disable-line no-unused-expressions, max-len
     });
@@ -408,6 +416,7 @@ describe('Component: Geosuggest', () => {
       TestUtils.Simulate.change(geoSuggestInput);
       geoSuggestInput.value = 'New York';
       TestUtils.Simulate.change(geoSuggestInput);
+      TestUtils.Simulate.focus(geoSuggestInput);
 
       expect(onActivateSuggest.calledOnce).to.be.true; // eslint-disable-line no-unused-expressions, max-len
     });
@@ -416,6 +425,7 @@ describe('Component: Geosuggest', () => {
       const geoSuggestInput = TestUtils.findRenderedDOMComponentWithClass(component, 'geosuggest__input'); // eslint-disable-line max-len
       geoSuggestInput.value = 'New';
       TestUtils.Simulate.change(geoSuggestInput);
+      TestUtils.Simulate.focus(geoSuggestInput);
 
       setImmediate(() => {
         const activeItems = TestUtils.scryRenderedDOMComponentsWithClass(component, 'geosuggest-item--active'); // eslint-disable-line max-len


### PR DESCRIPTION
<!-- Please fill out the title field according to our commit conventions -->

### Description

Fixes a bug where suggestlist was not hidden when input blur is triggered. This bug is mentioned in issue #179 

### Checklist

<!-- Mark these as checked by replacing [ ] with [x] -->
- [x] All tests passing
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
- [x] Commits and PR follow conventions

