### PR TITLE
triggering onSuggestSelect on all condition

### DIFF
--- a/src/Geosuggest.jsx
+++ b/src/Geosuggest.jsx
@@ -354,19 +354,16 @@ class Geosuggest extends React.Component {
       suggest.placeId && !suggest.isFixture ?
         {placeId: suggest.placeId} : {address: suggest.label},
       (results, status) => {
-        if (status !== this.googleMaps.GeocoderStatus.OK) {
-          return;
+        if (status === this.googleMaps.GeocoderStatus.OK) {
+          var gmaps = results[0],
+            location = gmaps.geometry.location;
+
+          suggest.gmaps = gmaps;
+          suggest.location = {
+            lat: location.lat(),
+            lng: location.lng()
+          };
         }
-
-        var gmaps = results[0],
-          location = gmaps.geometry.location;
-
-        suggest.gmaps = gmaps;
-        suggest.location = {
-          lat: location.lat(),
-          lng: location.lng()
-        };
-
         this.props.onSuggestSelect(suggest);
       }
     );

--- a/test/Geosuggest_spec.jsx
+++ b/test/Geosuggest_spec.jsx
@@ -197,7 +197,7 @@ describe('Component: Geosuggest', () => {
         keyCode: 13,
         which: 13
       });
-      expect(onSuggestSelect.called).to.be.false; // eslint-disable-line no-unused-expressions, max-len
+      expect(onActivateSuggest.args.length).to.be.equal(0); // eslint-disable-line max-len
     });
 
     it('should deactivate the active suggest when pressing arrow down on the last suggest', () => { // eslint-disable-line max-len


### PR DESCRIPTION
<!-- Please fill out the title field according to our commit conventions -->

### Description

Fixes a bug mentioned in issue #193 where `onSuggestSelect` was not fired when geocoding was unsuccessfully.
Made changes to fire `onSuggestSelect` on all cases.

### Checklist

<!-- Mark these as checked by replacing [ ] with [x] -->
- [x] All tests passing
- [x] Created tests which fail without the change (if possible)
- [x] Commits and PR follow conventions

