### PR TITLE
refactor(shallowCompare) changed to use reacts internal func

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.0.1
+
+#### Bug Fixes
+
+* **refactor:** changed to use reacts internal shallowCompare  
+
 ## 2.0.0 (2016-10-07)
 
 

--- a/README.md
+++ b/README.md
@@ -35,14 +35,6 @@ You can also use the standalone build by including `dist/react-geosuggest.js` in
 npm install react-geosuggest --save
 ```
 
-### Peer Dependencies
-
-To allow for the greatest flexiblity in react version support, this module specifies `react-addons-shallow-compare` as a peer dependency. Therefore in order to use it, you must also install a version of `react-addons-shallow-compare` that matches your `react` version, ie:
-
-```
-npm install react-addons-shallow-compare@0.14.6
-```
-
 ## Usage
 
 The Geosuggest works out of the box by just including it. However, you can customize the behaviour with the properties noted below.

--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
     "url": "https://github.com/ubilabs/react-geosuggest/issues"
   },
   "peerDependencies": {
-    "react": "^0.14.0 || ^15.0.0",
-    "react-addons-shallow-compare": "^0.14.0 || ^15.0.0"
+    "react": "^0.14.0 || ^15.0.0"
   },
   "dependencies": {
     "classnames": "^2.2.3",
@@ -43,7 +42,6 @@
     "nyc": "^6.4.4",
     "react": "^15.1.0",
     "react-addons-test-utils": "^15.1.0",
-    "react-addons-shallow-compare": "^15.1.0",
     "react-dom": "^15.1.0",
     "sinon": "^1.17.3",
     "uglifyjs": "^2.4.10"

--- a/src/input.jsx
+++ b/src/input.jsx
@@ -1,5 +1,5 @@
 import React from 'react'; // eslint-disable-line no-unused-vars
-import shallowCompare from 'react-addons-shallow-compare';
+import shallowCompare from 'react/lib/shallowCompare';
 import classnames from 'classnames';
 
 import filterInputAttributes from './filter-input-attributes';

--- a/src/suggest-item.jsx
+++ b/src/suggest-item.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import shallowCompare from 'react-addons-shallow-compare';
+import shallowCompare from 'react/lib/shallowCompare';
 import classnames from 'classnames';
 
 /**

--- a/src/suggest-list.jsx
+++ b/src/suggest-list.jsx
@@ -1,5 +1,5 @@
 import React from 'react'; // eslint-disable-line no-unused-vars
-import shallowCompare from 'react-addons-shallow-compare';
+import shallowCompare from 'react/lib/shallowCompare';
 import classnames from 'classnames';
 import SuggestItem from './suggest-item';
 


### PR DESCRIPTION
<!-- Please fill out the title field according to our commit conventions -->

### Description

Removed the peer dependency on react-addons-shallow-compare in favour of reacts internal shallowCompare. Suggested here: https://github.com/ubilabs/react-geosuggest/pull/200#issuecomment-254677912

### Checklist

<!-- Mark these as checked by replacing [ ] with [x] -->
- [x] All tests passing
- [x] Created tests which fail without the change (if possible): not possible
- [x] Extended the README / documentation, if necessary
- [x] Commits and PR follow conventions

