### PR TITLE
refactor(css): removed dupe font size declaration

### DIFF
--- a/src/geosuggest.css
+++ b/src/geosuggest.css
@@ -1,5 +1,6 @@
 /**
  * The geosuggest module
+ * NOTE: duplicated font-sizes' are for browsers which don't support rem (only IE 8)
  */
 .geosuggest {
   font-size: 18px;


### PR DESCRIPTION
### Description

There is a duplicate declaration of `font-size` in the `geosuggest.css`. I removed the non `rem` declaration.
### Checklist

<!-- Mark these as checked by replacing [ ] with [x] -->
- [x ] All tests passing
- [ x] Created tests which fail without the change (if possible)
- [ x] Extended the README / documentation, if necessary
- [ x] Commits and PR follow conventions
