### PR TITLE
Fixed scroll problems, maxFixtures prop, new ref pattern

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -185,7 +185,6 @@
     "no-ternary": 0,
     "no-trailing-spaces": 2,
     "no-underscore-dangle": 1,
-    "one-var": 2,
     "operator-assignment": 0,
     "padded-blocks": [1, "never"],
     "quote-props": [0, "as-needed", {
@@ -220,7 +219,7 @@
     }],
 
     "max-depth": [1, 3],
-    "max-len": [2, 80, 2],
+    "max-len": [2, 120, 2],
     "max-params": [2, 4],
     "max-statements": [1, 15],
     "no-bitwise": 2,
@@ -235,6 +234,8 @@
     "prefer-reflect": 1,
     "prefer-spread": 1,
     "require-yield": 2,
-    "react/jsx-no-bind": 2
+    "react/jsx-no-bind": [2, {
+      "ignoreRefs": true
+    }]
   }
 }

--- a/README.md
+++ b/README.md
@@ -136,6 +136,12 @@ An array with fixtures (defaults). Each fixture has to be an object with a `labe
 
 You can also add a `className` key to a fixture. This class will be applied to the fixture item.
 
+### maxFixtures
+Type: `Number`
+Default: `10`
+
+Maximum number of fixtures to render.
+
 #### googleMaps
 Type: `Object`
 Default: `google.maps`

--- a/src/Geosuggest.jsx
+++ b/src/Geosuggest.jsx
@@ -384,7 +384,7 @@ class Geosuggest extends React.Component {
       ),
       shouldRenderLabel = this.props.label && attributes.id,
       input = <Input className={this.props.inputClassName}
-        ref={input => this.input = input}
+        ref={i => this.input = i}
         value={this.state.userInput}
         ignoreEnter={!this.state.isSuggestsHidden}
         ignoreTab={this.props.ignoreTab}

--- a/src/Geosuggest.jsx
+++ b/src/Geosuggest.jsx
@@ -212,7 +212,7 @@ class Geosuggest extends React.Component {
     var suggests = [],
       regex = new RegExp(escapeRegExp(this.state.userInput), 'gim'),
       skipSuggest = this.props.skipSuggest,
-      maxFixtures = 10,
+      maxFixtures = this.props.maxFixtures,
       fixturesSearched = 0,
       activeSuggest = null;
 

--- a/src/Geosuggest.jsx
+++ b/src/Geosuggest.jsx
@@ -141,7 +141,7 @@ class Geosuggest extends React.Component {
    * Focus the input
    */
   focus() {
-    this.refs.input.focus();
+    this.input.focus();
   }
 
   /**
@@ -384,7 +384,7 @@ class Geosuggest extends React.Component {
       ),
       shouldRenderLabel = this.props.label && attributes.id,
       input = <Input className={this.props.inputClassName}
-        ref='input'
+        ref={input => this.input = input}
         value={this.state.userInput}
         ignoreEnter={!this.state.isSuggestsHidden}
         ignoreTab={this.props.ignoreTab}

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -4,6 +4,7 @@
  */
 export default {
   fixtures: [],
+  maxFixtures: 10,
   initialValue: '',
   placeholder: 'Search places',
   disabled: false,

--- a/src/input.jsx
+++ b/src/input.jsx
@@ -24,7 +24,7 @@ class Input extends React.Component {
    * When the input got changed
    */
   onChange = () => {
-    this.props.onChange(this.refs.input.value);
+    this.props.onChange(this.input.value);
   }
 
   /**
@@ -88,7 +88,7 @@ class Input extends React.Component {
    * Focus the input
    */
   focus() {
-    this.refs.input.focus();
+    this.input.focus();
   }
 
   /**
@@ -103,7 +103,7 @@ class Input extends React.Component {
       );
 
     return <input className={classes}
-      ref='input'
+      ref={input => this.input = input}
       type='text'
       autoComplete='off'
       {...attributes}

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -5,6 +5,7 @@ import React from 'react';
  */
 export default {
   fixtures: React.PropTypes.array,
+  maxFixtures: React.PropTypes.number,
   initialValue: React.PropTypes.string,
   placeholder: React.PropTypes.string,
   disabled: React.PropTypes.bool,

--- a/src/suggest-item.jsx
+++ b/src/suggest-item.jsx
@@ -35,10 +35,10 @@ export default class SuggestItem extends React.Component {
   scrollIfNeeded() {
     const el = this.ref;
     const parent = el.parentElement;
-    
+
     const overTop = el.offsetTop - parent.offsetTop < parent.scrollTop;
-    const overBottom = (el.offsetTop - parent.offsetTop + el.clientHeight) > (parent.scrollTop + parent.clientHeight);
-    
+    const overBottom = el.offsetTop - parent.offsetTop + el.clientHeight > parent.scrollTop + parent.clientHeight;
+
     if (overTop || overBottom) {
       parent.scrollTop = el.offsetTop - parent.offsetTop - parent.clientHeight / 2 + el.clientHeight / 2;
     }

--- a/src/suggest-item.jsx
+++ b/src/suggest-item.jsx
@@ -19,6 +19,32 @@ export default class SuggestItem extends React.Component {
   }
 
   /**
+   * Checking if item just became active and scrolling if needed.
+   * @param {Object} nextProps The new properties
+   */
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.isActive && !this.props.isActive) {
+      this.scrollIfNeeded();
+    }
+  }
+
+  /**
+   * Scrolling current item to the center of the list if item needs scrolling.
+   * Item is scrolled to the center of the list.
+   */
+  scrollIfNeeded() {
+    const el = this.ref;
+    const parent = el.parentElement;
+    
+    const overTop = el.offsetTop - parent.offsetTop < parent.scrollTop;
+    const overBottom = (el.offsetTop - parent.offsetTop + el.clientHeight) > (parent.scrollTop + parent.clientHeight);
+    
+    if (overTop || overBottom) {
+      parent.scrollTop = el.offsetTop - parent.offsetTop - parent.clientHeight / 2 + el.clientHeight / 2;
+    }
+  }
+
+  /**
    * When the suggest item got clicked
    * @param {Event} event The click event
    */
@@ -39,6 +65,7 @@ export default class SuggestItem extends React.Component {
     );
 
     return <li className={classes}
+      ref={li => this.ref = li }
       style={this.props.style}
       onMouseDown={this.props.onMouseDown}
       onMouseOut={this.props.onMouseOut}

--- a/test/Geosuggest_spec.jsx
+++ b/test/Geosuggest_spec.jsx
@@ -275,7 +275,7 @@ describe('Component: Geosuggest', () => {
     });
 
     it('should call `onSuggestNoResults` when there are no suggestions', () => {
-      const input = component.refs.input,
+      const input = component.input,
         geoSuggestInput = TestUtils.findRenderedDOMComponentWithClass(component, 'geosuggest__input'); // eslint-disable-line max-len
 
       input.value = 'There is no result for this. Really.';


### PR DESCRIPTION
### Description

- added `maxFixtures` prop to allow configuration of the number of fixtures being shown. Default is set to `10` which was hardcoded so far.
- Updating refs to new pattern
- When there is a lot of fixtures and scroll appears, if you use arrow keys to move through the list you can move to the item which is not visible due to scroll. Fixed it by scrolling item to center if item is not visible.
- small modification of `.eslintrc`

### Checklist

<!-- Mark these as checked by replacing [ ] with [x] -->
- [x] All tests passing
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
- [x] Commits and PR follow conventions
