### PR TITLE
Geocode using Google Place Details Service

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -235,6 +235,7 @@
     "prefer-reflect": 1,
     "prefer-spread": 1,
     "require-yield": 2,
-    "react/jsx-no-bind": 2
+    "react/jsx-no-bind": 2,
+    "react/jsx-uses-react": 1
   }
 }

--- a/src/Geosuggest.jsx
+++ b/src/Geosuggest.jsx
@@ -81,6 +81,17 @@ class Geosuggest extends React.Component {
   }
 
   /**
+   * Called on the client side after component is mounted.
+   * Google Places Service will be instantiated with an invisible DOM node
+   * and cached as a instance property
+   */
+  componentDidMount() {
+    this.placesService = new this.googleMaps.places.PlacesService(
+      this.attrContainer
+    );
+  }
+
+  /**
    * When the component will unmount
    */
   componentWillUnmount() {
@@ -429,7 +440,11 @@ class Geosuggest extends React.Component {
         onSuggestNoResults={this.onSuggestNoResults}
         onSuggestMouseDown={this.onSuggestMouseDown}
         onSuggestMouseOut={this.onSuggestMouseOut}
-        onSuggestSelect={this.selectSuggest}/>;
+        onSuggestSelect={this.selectSuggest}/>,
+      attrContainer = React.cloneElement(
+        this.props.attrContainer,
+        {ref: container => this.attrContainer = container}
+      );
 
     return <div className={classes}>
       <div className="geosuggest__input-wrapper">
@@ -442,6 +457,7 @@ class Geosuggest extends React.Component {
       <div className="geosuggest__suggests-wrapper">
         {suggestionsList}
       </div>
+      {attrContainer}
     </div>;
   }
 }

--- a/src/Geosuggest.jsx
+++ b/src/Geosuggest.jsx
@@ -356,23 +356,41 @@ class Geosuggest extends React.Component {
    * @param  {Object} suggest The suggest
    */
   geocodeSuggest(suggest) {
-    this.geocoder.geocode(
-      suggest.placeId && !suggest.isFixture ?
-        {placeId: suggest.placeId} : {address: suggest.label},
-      (results, status) => {
-        if (status === this.googleMaps.GeocoderStatus.OK) {
-          var gmaps = results[0],
-            location = gmaps.geometry.location;
+    if (suggest.isFixture) {
+      this.geocoder.geocode(
+        {address: suggest.label},
+        (results, status) => {
+          if (status === this.googleMaps.GeocoderStatus.OK) {
+            var gmaps = results[0],
+              location = gmaps.geometry.location;
 
-          suggest.gmaps = gmaps;
-          suggest.location = {
-            lat: location.lat(),
-            lng: location.lng()
-          };
+            suggest.gmaps = gmaps;
+            suggest.location = {
+              lat: location.lat(),
+              lng: location.lng()
+            };
+          }
+          this.props.onSuggestSelect(suggest);
         }
-        this.props.onSuggestSelect(suggest);
-      }
-    );
+      );
+    } else {
+      this.placesService.getDetails(
+        {placeId: suggest.placeId},
+        (result, status) => {
+          if (status === this.googleMaps.places.PlacesServiceStatus.OK) {
+            var gmaps = result,
+              location = gmaps.geometry.location;
+
+            suggest.gmaps = gmaps;
+            suggest.location = {
+              lat: location.lat(),
+              lng: location.lng()
+            };
+          }
+          this.props.onSuggestSelect(suggest);
+        }
+      );
+    }
   }
 
   /**

--- a/src/Geosuggest.jsx
+++ b/src/Geosuggest.jsx
@@ -54,7 +54,7 @@ class Geosuggest extends React.Component {
   }
 
   /**
-   * Called on the client side after component is mounted.
+   * Called on the client side before component is mounted.
    * Google api sdk object will be obtained and cached as a instance property.
    * Necessary objects of google api will also be determined and saved.
    */

--- a/src/defaults.jsx
+++ b/src/defaults.jsx
@@ -1,3 +1,4 @@
+import React from 'react';
 /* istanbul ignore next */
 /**
  * Default values
@@ -30,5 +31,6 @@ export default {
     'suggests': {},
     'suggestItem': {}
   },
-  ignoreTab: false
+  ignoreTab: false,
+  attrContainer: <div style={{display: 'none'}} />
 };

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -36,5 +36,6 @@ export default {
     suggestItem: React.PropTypes.object
   }),
   ignoreTab: React.PropTypes.bool,
-  label: React.PropTypes.string
+  label: React.PropTypes.string,
+  attrContainer: React.PropTypes.element
 };


### PR DESCRIPTION
### Description

This PR switches to using the [Place Details](https://developers.google.com/maps/documentation/javascript/places#place_details) service instead of the [Geocoder](https://developers.google.com/maps/documentation/javascript/geocoding) service to workaround an issue on Google's servers.

The issue has since been fixed, but I'm unsure whether it will come back again, in which case this PR might be useful.

### Checklist

<!-- Mark these as checked by replacing [ ] with [x] -->
- [ ] All tests passing
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
- [ ] Commits and PR follow conventions
- [x] Didn't do any of this because Google fixed their services before I could finish