### PR TITLE
feat(maxFixtures) Added maxFixtures prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,12 @@ An array with fixtures (defaults). Each fixture has to be an object with a `labe
 
 You can also add a `className` key to a fixture. This class will be applied to the fixture item.
 
+### maxFixtures
+Type: `Number`
+Default: `10`
+ 
+Maximum number of fixtures to render.
+
 #### googleMaps
 Type: `Object`
 Default: `google.maps`

--- a/src/Geosuggest.jsx
+++ b/src/Geosuggest.jsx
@@ -218,7 +218,7 @@ class Geosuggest extends React.Component {
     var suggests = [],
       regex = new RegExp(escapeRegExp(this.state.userInput), 'gim'),
       skipSuggest = this.props.skipSuggest,
-      maxFixtures = 10,
+      maxFixtures = this.props.maxFixtures,
       fixturesSearched = 0,
       activeSuggest = null;
 

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -4,6 +4,7 @@
  */
 export default {
   fixtures: [],
+  maxFixtures: 10,
   initialValue: '',
   placeholder: 'Search places',
   disabled: false,

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -5,6 +5,7 @@ import React from 'react';
  */
 export default {
   fixtures: React.PropTypes.array,
+  maxFixtures: React.PropTypes.number,
   initialValue: React.PropTypes.string,
   placeholder: React.PropTypes.string,
   disabled: React.PropTypes.bool,

--- a/test/Geosuggest_spec.jsx
+++ b/test/Geosuggest_spec.jsx
@@ -393,6 +393,15 @@ describe('Component: Geosuggest', () => {
 
       expect(suggest.classList.contains('geosuggest__suggests--hidden')).to.be.false; // eslint-disable-line no-unused-expressions, max-len
     });
+
+    it('should show a maximum of `maxFixtures` fixtures', () => {
+      render({maxFixtures: 2, fixtures});
+      const geoSuggestInput = TestUtils.findRenderedDOMComponentWithClass(component, 'geosuggest__input'); // eslint-disable-line max-len
+      TestUtils.Simulate.focus(geoSuggestInput);
+
+      const suggestItems = TestUtils.scryRenderedDOMComponentsWithClass(component, 'geosuggest__item'); // eslint-disable-line max-len, one-var
+      expect(suggestItems.length).to.equal(2);
+    });
   });
 
   describe('with autoActivateFirstSuggest enabled', () => {


### PR DESCRIPTION
<!-- Please fill out the title field according to our commit conventions -->

### Description
Added maxFixtures prop to allow configuration of the number of fixtures being shown. Default is set to 10 which was hardcoded so far.

https://github.com/ubilabs/react-geosuggest/pull/228#discussion_r92420816

### Checklist

<!-- Mark these as checked by replacing [ ] with [x] -->
- [x] All tests passing
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
- [x] Commits and PR follow conventions
