### PR TITLE
fix(suggest-item) Items are not visible due to scroll when navigating using arrow keys

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -235,6 +235,8 @@
     "prefer-reflect": 1,
     "prefer-spread": 1,
     "require-yield": 2,
-    "react/jsx-no-bind": 2
+    "react/jsx-no-bind": [2, {
+      "ignoreRefs": true
+    }]
   }
 }

--- a/src/suggest-item.jsx
+++ b/src/suggest-item.jsx
@@ -19,6 +19,31 @@ export default class SuggestItem extends React.Component {
   }
 
   /**
+   * Checking if item just became active and scrolling if needed.
+   * @param {Object} nextProps The new properties
+   */
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.isActive && !this.props.isActive) {
+      this.scrollIfNeeded();
+    }
+  }
+
+  /**
+   * Scrolling current item to the center of the list if item needs scrolling.
+   * Item is scrolled to the center of the list.
+   */
+  scrollIfNeeded() {
+    const el = this.ref,
+      parent = el.parentElement,
+      overTop = el.offsetTop - parent.offsetTop < parent.scrollTop,
+      overBottom = el.offsetTop - parent.offsetTop + el.clientHeight > parent.scrollTop + parent.clientHeight;    // eslint-disable-line max-len
+
+    if (overTop || overBottom) {
+      parent.scrollTop = el.offsetTop - parent.offsetTop - parent.clientHeight / 2 + el.clientHeight / 2;   // eslint-disable-line max-len
+    }
+  }
+
+  /**
    * When the suggest item got clicked
    * @param {Event} event The click event
    */
@@ -42,6 +67,7 @@ export default class SuggestItem extends React.Component {
     );
 
     return <li className={classes}
+      ref={li => this.ref = li}
       style={this.props.style}
       onMouseDown={this.props.onMouseDown}
       onMouseOut={this.props.onMouseOut}


### PR DESCRIPTION
<!-- Please fill out the title field according to our commit conventions -->

### Description
When there is a lot of fixtures and scroll appears, if you use arrow keys to move through the list you can move to the item which is not visible due to scroll. Fixed it by scrolling item to center if item is not visible.
https://github.com/ubilabs/react-geosuggest/pull/228#discussion_r92421044

### Checklist

<!-- Mark these as checked by replacing [ ] with [x] -->
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Commits and PR follow conventions
