### PR TITLE
fix: update PropTypes to support country arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Default: `null`
 The bounds to use for biasing the suggests. If this is set, `location` and `radius` are ignored.
 
 #### country
-Type: `String`
+Type: `String` | `Array<String>`
 Default: `null`
 
 Restricts predictions to the specified country (ISO 3166-1 Alpha-2 country code, case insensitive). E.g., us, br, au.

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -20,7 +20,10 @@ export default {
     React.PropTypes.number
   ]),
   bounds: React.PropTypes.object,
-  country: React.PropTypes.string,
+  country: React.PropTypes.oneOfType([
+    React.PropTypes.string,
+    React.PropTypes.array
+  ]),
   types: React.PropTypes.array,
   queryDelay: React.PropTypes.number,
   googleMaps: React.PropTypes.object,


### PR DESCRIPTION
<!-- Please fill out the title field according to our commit conventions -->

### Description

Adds support for providing an array of countries instead of a single country.
from [Google Maps API](https://developers.google.com/maps/documentation/javascript/3.exp/reference#ComponentRestrictions)
```
Type:  string|Array<string>
Restricts predictions to the specified country (ISO 3166-1 Alpha-2 country code, case insensitive). E.g., us, br, au. You can provide a single one, or an array of up to 5 country code strings.
```

### Checklist

<!-- Mark these as checked by replacing [ ] with [x] -->
- [x] All tests passing
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
- [x] Commits and PR follow conventions
