### PR TITLE
feat(geocode): Add ability to disable geocoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,12 @@ Default: `function(suggest) {}`
 
 If the function returns true then the suggest will not be included in the displayed results. Only parameter is an object with data of the selected suggest. (See above)
 
+#### skipGeocode
+Type: `Boolean`
+Default: `false`
+
+If false, the selected suggestion will be geocoded using Google's Geocoding API. If true, the suggestion will not be geocoded.
+
 #### autoActivateFirstSuggest
 Type: `Boolean`
 Default: `false`

--- a/src/Geosuggest.jsx
+++ b/src/Geosuggest.jsx
@@ -348,10 +348,10 @@ class Geosuggest extends React.Component {
       return;
     }
 
-    if (!this.props.skipGeocode) {
-      this.geocodeSuggest(suggest);
-    } else {
+    if (this.props.skipGeocode) {
       this.props.onSuggestSelect(suggest);
+    } else {
+      this.geocodeSuggest(suggest);
     }
   }
 

--- a/src/Geosuggest.jsx
+++ b/src/Geosuggest.jsx
@@ -348,7 +348,11 @@ class Geosuggest extends React.Component {
       return;
     }
 
-    this.geocodeSuggest(suggest);
+    if (!this.props.skipGeocode) {
+      this.geocodeSuggest(suggest);
+    } else {
+      this.props.onSuggestSelect(suggest);
+    }
   }
 
   /**
@@ -413,7 +417,8 @@ class Geosuggest extends React.Component {
         onSuggestNoResults={this.onSuggestNoResults}
         onSuggestMouseDown={this.onSuggestMouseDown}
         onSuggestMouseOut={this.onSuggestMouseOut}
-        onSuggestSelect={this.selectSuggest}/>;
+        onSuggestSelect={this.selectSuggest}
+        skipGeocode={this.props.skipGeocode} />;
 
     return <div className={classes}>
       <div className="geosuggest__input-wrapper">

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -30,5 +30,6 @@ export default {
     'suggests': {},
     'suggestItem': {}
   },
-  ignoreTab: false
+  ignoreTab: false,
+  skipGeocode: false
 };

--- a/test/Geosuggest_spec.jsx
+++ b/test/Geosuggest_spec.jsx
@@ -16,6 +16,7 @@ describe('Component: Geosuggest', () => {
     onKeyPress = null,
     onChange = null,
     onBlur = null,
+    geocodeSuggest = null,
     render = props => {
       onSuggestSelect = sinon.spy();
       onActivateSuggest = sinon.spy();
@@ -24,6 +25,7 @@ describe('Component: Geosuggest', () => {
       onFocus = sinon.spy();
       onKeyPress = sinon.spy();
       onBlur = sinon.spy();
+      geocodeSuggest = sinon.spy();
 
       component = TestUtils.renderIntoDocument(
         <Geosuggest
@@ -528,6 +530,27 @@ describe('Component: Geosuggest', () => {
         expect(totalItems.length).to.be.equal(itemsWithItemClass.length);
         done();
       });
+    });
+  });
+
+  describe('with skipGeocode', () => { // eslint-disable-line max-len
+    const props = {
+      skipGeocode: true
+    };
+
+    beforeEach(() => render(props));
+
+    it('should call `onSuggestSelect` when we type a city name and click on one of the suggestions', () => { // eslint-disable-line max-len
+      const geoSuggestInput = TestUtils.findRenderedDOMComponentWithClass(component, 'geosuggest__input'); // eslint-disable-line max-len
+      geoSuggestInput.value = 'New';
+      TestUtils.Simulate.change(geoSuggestInput);
+      TestUtils.Simulate.focus(geoSuggestInput);
+
+      const suggestItems = TestUtils.scryRenderedDOMComponentsWithClass(component, 'geosuggest__item'); // eslint-disable-line max-len, one-var
+      TestUtils.Simulate.click(suggestItems[0]);
+      expect(onSuggestSelect.calledOnce).to.be.true; // eslint-disable-line no-unused-expressions, max-len
+
+      expect(geocodeSuggest.called).to.be.false; // eslint-disable-line no-unused-expressions, max-len
     });
   });
 });


### PR DESCRIPTION
<!-- Please fill out the title field according to our commit conventions -->

### Description

Adds a new property `skipGeocode` whose default is `false` that will determine whether a suggestion is geocoded or not.

### Checklist

<!-- Mark these as checked by replacing [ ] with [x] -->
- [x] All tests passing
- [ ] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
- [x] Commits and PR follow conventions
