### PR TITLE
docs(readme): correct a badly formed link

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ As this component uses the Google Maps Places API to get suggests, you must incl
 </html>
 ```
 
-Visit the [Google Developer Console](https://console.developers.google.com) to generate your API key. The API's that you have to enable in your Google API Manager Dashboard are [Google Maps Geocoding API](https://developers.google.com/maps/documentation/geocoding/start), [Google Places API Web Service](https://developers.google.com/places/web-service/) and [Google Maps Javascript API] (https://developers.google.com/maps/documentation/javascript/).
+Visit the [Google Developer Console](https://console.developers.google.com) to generate your API key. The API's that you have to enable in your Google API Manager Dashboard are [Google Maps Geocoding API](https://developers.google.com/maps/documentation/geocoding/start), [Google Places API Web Service](https://developers.google.com/places/web-service/) and [Google Maps Javascript API](https://developers.google.com/maps/documentation/javascript/).
 
 The easiest way to use geosuggest is to install it from NPM and include it in your own React build process (using [Browserify](http://browserify.org), [Webpack](http://webpack.github.io/), etc).
 


### PR DESCRIPTION
<!-- Please fill out the title field according to our commit conventions -->

### Description

Removed a space between title/link brackets in the Google Maps Javascript API link.

### Checklist

<!-- Mark these as checked by replacing [ ] with [x] -->
- [x] All tests passing
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
- [x] Commits and PR follow conventions
