### PR TITLE
fix(Geosuggest): add description to keep the original value with custom labels

### DIFF
--- a/src/Geosuggest.jsx
+++ b/src/Geosuggest.jsx
@@ -239,6 +239,7 @@ class Geosuggest extends React.Component {
     suggestsGoogle.forEach(suggest => {
       if (!skipSuggest(suggest)) {
         suggests.push({
+          description: suggest.description,
           label: this.props.getSuggestLabel(suggest),
           placeId: suggest.place_id,
           isFixture: false
@@ -339,7 +340,7 @@ class Geosuggest extends React.Component {
 
     this.setState({
       isSuggestsHidden: true,
-      userInput: suggest.label
+      userInput: suggest.description || suggest.label
     });
 
     if (suggest.location) {

--- a/src/Geosuggest.jsx
+++ b/src/Geosuggest.jsx
@@ -340,7 +340,9 @@ class Geosuggest extends React.Component {
 
     this.setState({
       isSuggestsHidden: true,
-      userInput: suggest.description || suggest.label
+      userInput: typeof suggest.label !== 'object' ?
+        suggest.label :
+        suggest.description
     });
 
     if (suggest.location) {


### PR DESCRIPTION
### Description

Fixes a bug where the input value after selecting a suggest looks like `[Object object]` happened when you are returning a React element inside the suggest label trough the `getSuggestLabel` prop.

I have found a related closed issue here https://github.com/ubilabs/react-geosuggest/issues/204.

This is the basic approach to solve the issue now and to keep the backward compatibility, but we can think something more complex to keep your API values.

### Checklist

<!-- Mark these as checked by replacing [ ] with [x] -->
- [x] All tests passing
- [ ] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
- [x] Commits and PR follow conventions
