### PR TITLE
Do not trigger onSuggestSelect on Enter keypress if there is no activ…

### DIFF
--- a/src/Geosuggest.jsx
+++ b/src/Geosuggest.jsx
@@ -126,7 +126,11 @@ class Geosuggest extends React.Component {
 
   onPrev = () => this.activateSuggest('prev')
 
-  onSelect = () => this.selectSuggest(this.state.activeSuggest)
+  onSelect = () => {
+    if (this.state.activeSuggest) {
+      this.selectSuggest(this.state.activeSuggest);
+    }
+  }
 
   onSuggestMouseDown = () => this.setState({ignoreBlur: true})
 


### PR DESCRIPTION
…eSuggest in state

<!-- Please fill out the title field according to our commit conventions -->

### Description

Fixes a bug where 'pressing enter while no suggest is selected fires onSuggestSelect event' happened when 'enter keypress in input box'

### Checklist

<!-- Mark these as checked by replacing [ ] with [x] -->
- [x] All tests passing
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
- [x] Commits and PR follow conventions
