### PR TITLE
Autocomplete as a prop instead of hardcoded - closes #303

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,12 @@ Default: `null`
 
 Additional `className` to add when a suggestion item is active.
 
+#### autoComplete
+Type: `String`,
+Default: `off`
+
+Autocomplete input attribute.
+
 #### Others
 
 All [allowed attributes for `input[type="text"]`](https://github.com/ubilabs/react-geosuggest/blob/master/src/filter-input-attributes.js#L4)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-geosuggest",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "A React autosuggest for the Google Maps Places API.",
   "main": "module/Geosuggest.js",
   "author": "Robert Katzki <katzki@ubilabs.net>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-geosuggest",
-  "version": "2.1.1",
+  "version": "2.1.0",
   "description": "A React autosuggest for the Google Maps Places API.",
   "main": "module/Geosuggest.js",
   "author": "Robert Katzki <katzki@ubilabs.net>",

--- a/src/filter-input-attributes.js
+++ b/src/filter-input-attributes.js
@@ -3,6 +3,7 @@
  */
 const allowedAttributes = [
   'autoFocus',
+  'autoComplete',
   'disabled',
   'form',
   'formAction',

--- a/src/input.jsx
+++ b/src/input.jsx
@@ -112,7 +112,6 @@ class Input extends React.Component {
     return <input className={classes}
       ref='input'
       type='text'
-      autoComplete='off'
       {...attributes}
       value={this.props.value}
       style={this.props.style}
@@ -133,7 +132,8 @@ Input.defaultProps = {
   value: '',
   ignoreTab: false,
   onKeyDown: () => {},
-  onKeyPress: () => {}
+  onKeyPress: () => {},
+  autoComplete: 'off'
 };
 
 export default Input;

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -38,5 +38,6 @@ export default {
     suggestItem: React.PropTypes.object
   }),
   ignoreTab: React.PropTypes.bool,
-  label: React.PropTypes.string
+  label: React.PropTypes.string,
+  autoComplete: React.PropTypes.string
 };


### PR DESCRIPTION
<!-- Please fill out the title field according to our commit conventions -->

### Description
Give control to the developer to decide if they want to use autocomplete. This is valuable since some forms begin with name/email/username etc, and they may still want the address to autofill if they autocomplete one of these fields. It is still defaulted to `"off"`, so behavior won't change unless desired.

### Checklist

<!-- Mark these as checked by replacing [ ] with [x] -->
- [x] All tests passing
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
- [x] Commits and PR follow conventions

Closes #303 