### PR TITLE
feature(renderSuggestItem)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-geosuggest",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "A React autosuggest for the Google Maps Places API.",
   "main": "module/Geosuggest.js",
   "author": "Robert Katzki <katzki@ubilabs.net>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-geosuggest",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "A React autosuggest for the Google Maps Places API.",
   "main": "module/Geosuggest.js",
   "author": "Robert Katzki <katzki@ubilabs.net>",

--- a/src/Geosuggest.jsx
+++ b/src/Geosuggest.jsx
@@ -413,7 +413,8 @@ class Geosuggest extends React.Component {
         onSuggestNoResults={this.onSuggestNoResults}
         onSuggestMouseDown={this.onSuggestMouseDown}
         onSuggestMouseOut={this.onSuggestMouseOut}
-        onSuggestSelect={this.selectSuggest}/>;
+        onSuggestSelect={this.selectSuggest}
+        renderSuggestItem={this.props.renderSuggestItem}/>;
 
     return <div className={classes}>
       <div className="geosuggest__input-wrapper">

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -24,6 +24,7 @@ export default {
   onChange: () => {},
   skipSuggest: () => {},
   getSuggestLabel: suggest => suggest.description,
+  renderSuggestItem: null,
   autoActivateFirstSuggest: false,
   style: {
     'input': {},

--- a/src/filter-input-attributes.js
+++ b/src/filter-input-attributes.js
@@ -2,6 +2,7 @@
  * Attributes allowed on input elements
  */
 const allowedAttributes = [
+  'autoComplete',
   'autoFocus',
   'disabled',
   'form',

--- a/src/input.jsx
+++ b/src/input.jsx
@@ -112,7 +112,6 @@ class Input extends React.Component {
     return <input className={classes}
       ref='input'
       type='text'
-      autoComplete='off'
       {...attributes}
       value={this.props.value}
       style={this.props.style}
@@ -133,7 +132,8 @@ Input.defaultProps = {
   value: '',
   ignoreTab: false,
   onKeyDown: () => {},
-  onKeyPress: () => {}
+  onKeyPress: () => {},
+  autoComplete: 'off'
 };
 
 export default Input;

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -31,6 +31,7 @@ export default {
   onKeyPress: React.PropTypes.func,
   skipSuggest: React.PropTypes.func,
   getSuggestLabel: React.PropTypes.func,
+  renderSuggestItem: React.PropTypes.func,
   autoActivateFirstSuggest: React.PropTypes.bool,
   style: React.PropTypes.shape({
     input: React.PropTypes.object,

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -38,5 +38,6 @@ export default {
     suggestItem: React.PropTypes.object
   }),
   ignoreTab: React.PropTypes.bool,
-  label: React.PropTypes.string
+  label: React.PropTypes.string,
+  autoComplete: React.PropTypes.string
 };

--- a/src/suggest-item.jsx
+++ b/src/suggest-item.jsx
@@ -46,7 +46,9 @@ export default class SuggestItem extends React.Component {
       onMouseDown={this.props.onMouseDown}
       onMouseOut={this.props.onMouseOut}
       onClick={this.onClick}>
-        {this.props.suggest.label}
+        { this.props.renderSuggestItem
+            ? this.props.renderSuggestItem(this.props.suggest)
+            : this.props.suggest.label }
     </li>;
   }
 }

--- a/src/suggest-list.jsx
+++ b/src/suggest-list.jsx
@@ -55,9 +55,10 @@ export default class SuggestList extends React.Component {
     return <ul className={classes} style={this.props.style}>
       {this.props.suggests.map(suggest => {
         const isActive = this.props.activeSuggest &&
-          suggest.placeId === this.props.activeSuggest.placeId;
+          suggest.placeId === this.props.activeSuggest.placeId,
+          key = suggest.key || suggest.placeId;
 
-        return <SuggestItem key={suggest.placeId}
+        return <SuggestItem key={key}
           className={suggest.className}
           suggest={suggest}
           style={this.props.suggestItemStyle}
@@ -66,7 +67,8 @@ export default class SuggestList extends React.Component {
           activeClassname={this.props.suggestItemActiveClassName}
           onMouseDown={this.props.onSuggestMouseDown}
           onMouseOut={this.props.onSuggestMouseOut}
-          onSelect={this.props.onSuggestSelect} />;
+          onSelect={this.props.onSuggestSelect}
+          renderSuggestItem={ this.props.renderSuggestItem }/>;
       })}
     </ul>;
   }

--- a/test/Geosuggest_spec.jsx
+++ b/test/Geosuggest_spec.jsx
@@ -530,4 +530,32 @@ describe('Component: Geosuggest', () => {
       });
     });
   });
+
+  describe('with renderSuggestItem with custom fixture attributes', () => {
+    const fixtures = [
+        {label: 'New York', location: {lat: 40.7033127, lng: -73.979681}, firstName: 'John'} // eslint-disable-line max-len
+      ],
+      renderSuggestItem = suggest => {
+        return <span className="my-custom-suggest-item">
+            <span className="my-custom-suggest-item__first-name">
+              { suggest.firstName }
+            </span>
+            <span>{ suggest.label }</span>
+          </span>;
+      };
+
+    beforeEach(() => render({fixtures, renderSuggestItem}));
+
+    it('should render result of renderSuggestItem into the SuggestItem', () => {
+      const geoSuggestInput = TestUtils.findRenderedDOMComponentWithClass(component, 'geosuggest__input'); // eslint-disable-line max-len
+
+      TestUtils.Simulate.focus(geoSuggestInput);
+
+      const wrapper = TestUtils.scryRenderedDOMComponentsWithClass(component, 'my-custom-suggest-item'), // eslint-disable-line one-var, max-len
+        innerContent = TestUtils.scryRenderedDOMComponentsWithClass(component, 'my-custom-suggest-item__first-name'); // eslint-disable-line one-var, max-len
+
+      expect(wrapper).to.exist; // eslint-disable-line no-unused-expressions
+      expect(innerContent).to.exist; // eslint-disable-line no-unused-expressions, max-len
+    });
+  });
 });


### PR DESCRIPTION

### Description

Adds a new prop `renderSuggestItem` for controlling what is rendered inside of the suggest item component. Also adds ability for a fixture to specify a key other than than the label as the placeId, which is useful if multiple fixtures share the same address label.

### Checklist

<!-- Mark these as checked by replacing [ ] with [x] -->
- [x] All tests passing
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
- [x] Commits and PR follow conventions
