### PR TITLE
feat(SuggestItem): Add renderSuggestItem prop for custom suggest item templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,12 @@ Default: `function(suggest) { return suggest.description; }`
 
 Used to generate a custom label for a suggest. Only parameter is a suggest (google.maps.places.AutocompletePrediction). [Check the Google Maps Reference](https://developers.google.com/maps/documentation/javascript/reference#GeocoderResult) for more information on it’s structure.
 
+#### renderSuggestItem
+Type: `Function`
+Default: `null`
+
+Used to customize the inner html of SuggestItem and allows for controlling what properties of the suggest object you want to render. Also a convenient way to add additional styling to different rendered elements within SuggestItem.
+
 #### skipSuggest
 Type: `Function`
 Default: `function(suggest) {}`

--- a/src/Geosuggest.jsx
+++ b/src/Geosuggest.jsx
@@ -413,7 +413,8 @@ class Geosuggest extends React.Component {
         onSuggestNoResults={this.onSuggestNoResults}
         onSuggestMouseDown={this.onSuggestMouseDown}
         onSuggestMouseOut={this.onSuggestMouseOut}
-        onSuggestSelect={this.selectSuggest}/>;
+        onSuggestSelect={this.selectSuggest}
+        renderSuggestItem={this.props.renderSuggestItem}/>;
 
     return <div className={classes}>
       <div className="geosuggest__input-wrapper">

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -24,6 +24,7 @@ export default {
   onChange: () => {},
   skipSuggest: () => {},
   getSuggestLabel: suggest => suggest.description,
+  renderSuggestItem: null,
   autoActivateFirstSuggest: false,
   style: {
     'input': {},

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -31,6 +31,7 @@ export default {
   onKeyPress: React.PropTypes.func,
   skipSuggest: React.PropTypes.func,
   getSuggestLabel: React.PropTypes.func,
+  renderSuggestItem: React.PropTypes.func,
   autoActivateFirstSuggest: React.PropTypes.bool,
   style: React.PropTypes.shape({
     input: React.PropTypes.object,

--- a/src/suggest-item.jsx
+++ b/src/suggest-item.jsx
@@ -46,7 +46,9 @@ export default class SuggestItem extends React.Component {
       onMouseDown={this.props.onMouseDown}
       onMouseOut={this.props.onMouseOut}
       onClick={this.onClick}>
-        {this.props.suggest.label}
+        { this.props.renderSuggestItem
+            ? this.props.renderSuggestItem(this.props.suggest)
+            : this.props.suggest.label }
     </li>;
   }
 }

--- a/src/suggest-list.jsx
+++ b/src/suggest-list.jsx
@@ -55,9 +55,10 @@ export default class SuggestList extends React.Component {
     return <ul className={classes} style={this.props.style}>
       {this.props.suggests.map(suggest => {
         const isActive = this.props.activeSuggest &&
-          suggest.placeId === this.props.activeSuggest.placeId;
+          suggest.placeId === this.props.activeSuggest.placeId,
+          key = suggest.key || suggest.placeId;
 
-        return <SuggestItem key={suggest.placeId}
+        return <SuggestItem key={key}
           className={suggest.className}
           suggest={suggest}
           style={this.props.suggestItemStyle}
@@ -66,7 +67,8 @@ export default class SuggestList extends React.Component {
           activeClassname={this.props.suggestItemActiveClassName}
           onMouseDown={this.props.onSuggestMouseDown}
           onMouseOut={this.props.onSuggestMouseOut}
-          onSelect={this.props.onSuggestSelect} />;
+          onSelect={this.props.onSuggestSelect}
+          renderSuggestItem={ this.props.renderSuggestItem }/>;
       })}
     </ul>;
   }

--- a/test/Geosuggest_spec.jsx
+++ b/test/Geosuggest_spec.jsx
@@ -530,4 +530,32 @@ describe('Component: Geosuggest', () => {
       });
     });
   });
+
+  describe('with renderSuggestItem with custom fixture attributes', () => {
+    const fixtures = [
+        {label: 'New York', location: {lat: 40.7033127, lng: -73.979681}, firstName: 'John'} // eslint-disable-line max-len
+      ],
+      renderSuggestItem = suggest => {
+        return <span className="my-custom-suggest-item">
+            <span className="my-custom-suggest-item__first-name">
+              { suggest.firstName }
+            </span>
+            <span>{ suggest.label }</span>
+          </span>;
+      };
+
+    beforeEach(() => render({fixtures, renderSuggestItem}));
+
+    it('should render result of renderSuggestItem into the SuggestItem', () => {
+      const geoSuggestInput = TestUtils.findRenderedDOMComponentWithClass(component, 'geosuggest__input'); // eslint-disable-line max-len
+
+      TestUtils.Simulate.focus(geoSuggestInput);
+
+      const wrapper = TestUtils.scryRenderedDOMComponentsWithClass(component, 'my-custom-suggest-item'), // eslint-disable-line one-var, max-len
+        innerContent = TestUtils.scryRenderedDOMComponentsWithClass(component, 'my-custom-suggest-item__first-name'); // eslint-disable-line one-var, max-len
+
+      expect(wrapper).to.exist; // eslint-disable-line no-unused-expressions
+      expect(innerContent).to.exist; // eslint-disable-line no-unused-expressions, max-len
+    });
+  });
 });


### PR DESCRIPTION
<!-- Please fill out the title field according to our commit conventions -->

### Description

It may be useful to render additional suggest object properties other than label and have custom styling for those various components, or to wrap the label into different tags for custom styling of various parts of the label string. Take for example a custom fixture of the shape: 
```{label: 'New York', location: {lat: 40.7033127, lng: -73.979681}, firstName: 'John'}```
With `renderSuggestItem`, we can control the html output that is inserted into the SuggestItem component. Using the example, we could:
```jsx
renderSuggestItem(suggest) {
   return (
       <span className="my-custom-suggest-item">
            <span className="name">
                { suggest.firstName }
            </span>
            <span className="address">
                { suggest.label }
            </span>
        </span>
   );
}
```

Another use-case is for handling conditional styling based on suggest properties. Let's imagine that we want special treatment if the label is `New York`:

```jsx
renderSuggestItem(suggest) {
    let className = '';
    
    if (suggest.label === 'New York') {
        className = 'new-york';
    }

    return (
        <span className={ className }>
            suggest.label
        </span>
    );
}
```

### Checklist

<!-- Mark these as checked by replacing [ ] with [x] -->
- [x] All tests passing
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
- [x] Commits and PR follow conventions
