### PR TITLE
(fix) allow for shift + arrow key behavior in input box

### DIFF
--- a/src/input.jsx
+++ b/src/input.jsx
@@ -56,12 +56,16 @@ class Input extends React.Component {
   onInputKeyDown = event => { // eslint-disable-line complexity
     switch (event.which) {
       case 40: // DOWN
-        event.preventDefault();
-        this.props.onNext();
+        if (!event.isShiftKey) {
+          event.preventDefault();
+          this.props.onNext();
+        }
         break;
       case 38: // UP
-        event.preventDefault();
-        this.props.onPrev();
+        if (!event.isShiftKey) {
+          event.preventDefault();
+          this.props.onPrev();
+        }
         break;
       case 13: // ENTER
         if (this.props.ignoreEnter) {

--- a/src/input.jsx
+++ b/src/input.jsx
@@ -56,13 +56,13 @@ class Input extends React.Component {
   onInputKeyDown = event => { // eslint-disable-line complexity
     switch (event.which) {
       case 40: // DOWN
-        if (!event.isShiftKey) {
+        if (!event.shiftKey) {
           event.preventDefault();
           this.props.onNext();
         }
         break;
       case 38: // UP
-        if (!event.isShiftKey) {
+        if (!event.shiftKey) {
           event.preventDefault();
           this.props.onPrev();
         }


### PR DESCRIPTION
<!-- Please fill out the title field according to our commit conventions -->

### Description

The existing code was preventing default input behavior of highlighting
content of the input with shift and arrow keys.

### Checklist

<!-- Mark these as checked by replacing [ ] with [x] -->
- [x] All tests passing
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
- [x] Commits and PR follow conventions
