### PR TITLE
fix(Geosuggest.jsx): ponyfill Array.prototype.find to fix IE11 compat

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "react": "^0.14.0 || ^15.0.0"
   },
   "dependencies": {
+    "array-find": "^1.0.0",
     "classnames": "^2.2.3",
     "lodash.debounce": "^4.0.6",
     "react-addons-shallow-compare": "^15.5.2"

--- a/src/Geosuggest.jsx
+++ b/src/Geosuggest.jsx
@@ -3,6 +3,7 @@
 import React from 'react';
 import classnames from 'classnames';
 import debounce from 'lodash.debounce';
+import find from 'array-find';
 
 import defaults from './defaults';
 import propTypes from './prop-types';
@@ -268,7 +269,7 @@ class Geosuggest extends React.Component {
     let activeSuggest = this.state.activeSuggest;
 
     if (activeSuggest) {
-      const newSuggest = suggests.find(listedSuggest =>
+      const newSuggest = find(suggests, listedSuggest =>
         activeSuggest.placeId === listedSuggest.placeId &&
         activeSuggest.isFixture === listedSuggest.isFixture
       );


### PR DESCRIPTION
<!-- Please fill out the title field according to our commit conventions -->

### Description

This PR ponyfills `Array.prototype.find` with `array-find` to fix IE11 compatibility, as the said prototype method is not available on that browser at all. 

![image](https://user-images.githubusercontent.com/7641760/27264210-74c0a240-5482-11e7-8f2b-928ed2f843d3.png)


### Checklist

- [x] All tests passing
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
- [x] Commits and PR follow conventions

Signed-off-by: Pete Nykanen <pete.a.nykanen@gmail.com>

