### PR TITLE
fix(Geosuggest.jsx): Use filter over find to fix IE11 compatibility

### DIFF
--- a/src/Geosuggest.jsx
+++ b/src/Geosuggest.jsx
@@ -268,10 +268,10 @@ class Geosuggest extends React.Component {
     let activeSuggest = this.state.activeSuggest;
 
     if (activeSuggest) {
-      const newSuggest = suggests.find(listedSuggest =>
+      const newSuggest = suggests.filter(listedSuggest =>
         activeSuggest.placeId === listedSuggest.placeId &&
         activeSuggest.isFixture === listedSuggest.isFixture
-      );
+      )[0];
 
       activeSuggest = newSuggest || null;
     }


### PR DESCRIPTION
### Description

Continuing from #321, instead of ponyfilling we could just replace the call with `filter(...)[0]` as it's a sole use of the method. Filter always returns an array so calling `[0]` could return `undefined` if not found, as it does with `Array.prototype.find`.

### Checklist

- [x] All tests passing
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
- [x] Commits and PR follow conventions

Signed-off-by: Pete Nykanen pete.a.nykanen@gmail.com