### PR TITLE
fix(suggest-item): add missing key prop when rendering item

### DIFF
--- a/src/suggest-item.jsx
+++ b/src/suggest-item.jsx
@@ -34,7 +34,8 @@ export default class SuggestItem extends React.Component {
       length = suggest.matchedSubstrings.length,
       end = start + length,
       split = suggest.label.split(''),
-      boldPart = this.makeBold(suggest.label.substring(start, end));
+      boldPart = this.makeBold(suggest.label.substring(start, end),
+        suggest.label);
 
     split.splice(start, length, boldPart);
 


### PR DESCRIPTION
<!-- Please fill out the title field according to our commit conventions -->

### Description

On the live demo, when I start typing an address I get the following warning:

`Warning: Each child in an array or iterator should have a unique "key" prop. Check the render method of t`

The issue comes from the makeBold function which is expecting a key parameter. However, it's called without: this.makeBold(suggest.label.substring(start, end))
### Checklist

<!-- Mark these as checked by replacing [ ] with [x] -->
- [x] All tests passing
- [-] Created tests which fail without the change (if possible)
- [-] Extended the README / documentation, if necessary
- [x] Commits and PR follow conventions

Fixes #326 
