### PR TITLE
Fix: Consider location, bounds and componentRestrictions when geocoding

### DIFF
--- a/src/Geosuggest.jsx
+++ b/src/Geosuggest.jsx
@@ -367,9 +367,21 @@ class Geosuggest extends React.Component {
    * @param  {Object} suggest The suggest
    */
   geocodeSuggest(suggest) {
+    let options;
+    if (suggest.placeId && !suggest.isFixture) {
+      options = {
+        placeId: suggest.placeId,
+      };
+    } else {
+      options = {
+        address: suggest.label,
+        location: this.props.location,
+        bounds: this.props.bounds,
+        componentRestrictions: this.props.country ? { country: this.props.country } : undefined,
+      };
+    };
     this.geocoder.geocode(
-      suggest.placeId && !suggest.isFixture ?
-        {placeId: suggest.placeId} : {address: suggest.label},
+      options,
       (results, status) => {
         if (status === this.googleMaps.GeocoderStatus.OK) {
           var gmaps = results[0],

--- a/src/Geosuggest.jsx
+++ b/src/Geosuggest.jsx
@@ -367,19 +367,20 @@ class Geosuggest extends React.Component {
    * @param  {Object} suggest The suggest
    */
   geocodeSuggest(suggest) {
-    let options;
+    let options = null;
     if (suggest.placeId && !suggest.isFixture) {
       options = {
-        placeId: suggest.placeId,
+        placeId: suggest.placeId
       };
     } else {
       options = {
         address: suggest.label,
         location: this.props.location,
         bounds: this.props.bounds,
-        componentRestrictions: this.props.country ? { country: this.props.country } : undefined,
+        componentRestrictions: this.props.country ?
+        {country: this.props.country} : null
       };
-    };
+    }
     this.geocoder.geocode(
       options,
       (results, status) => {


### PR DESCRIPTION
### Description

Fixes a bug where the geocoder was not taking the `location`, `bounds` and `componentRestrictions` options when geocoding the user's input (no suggestion selected).

**Example**

- I want to autosuggest only places in Switzerland
- I want to bias results around Geneva
- => I define the `location` and `componentRestrictions` props.
- When the user writes "Rue du Lac", only streets with this name around Geneva are suggested: fine
- **BUT** if the user types enter without selecting any suggestion, the input gets geocoded without considering the options and google returns a place in the United States....

This pull requests fixes that behaviour.

As per google docs:

https://developers.google.com/maps/documentation/javascript/geocoding

The `GeocoderRequest` object literal contains the following fields:

```
{
 address: string,
 location: LatLng,
 placeId: string,
 bounds: LatLngBounds,
 componentRestrictions: GeocoderComponentRestrictions,
 region: string
}
```

So it makes sense that if they are defined in the props they should be used on both the autosuggest but also the geocoding. Closes #274.

### Checklist

<!-- Mark these as checked by replacing [ ] with [x] -->
- [x] All tests passing
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
- [x] Commits and PR follow conventions
