### PR TITLE
Call input blur() when suggestion is selected

### DIFF
--- a/src/Geosuggest.jsx
+++ b/src/Geosuggest.jsx
@@ -360,6 +360,10 @@ class Geosuggest extends React.Component {
     }
 
     this.geocodeSuggest(suggest);
+    // on `enter`, input is not blurred so we need
+    // to manually call blur() so that suggestions
+    // list will repopulate on focus()
+    this.blur();
   };
 
   /**

--- a/src/Geosuggest.jsx
+++ b/src/Geosuggest.jsx
@@ -360,9 +360,8 @@ class Geosuggest extends React.Component {
     }
 
     this.geocodeSuggest(suggest);
-    // on `enter`, input is not blurred so we need
-    // to manually call blur() so that suggestions
-    // list will repopulate on focus()
+    // on `enter`, input is not blurred
+    // Call blur() so the suggestions list will repopulate on focus()
     this.blur();
   };
 


### PR DESCRIPTION
### Description

Fixes an issue where the suggestions list would not repopulate if the suggestion was selected via the `enter` key press. However, if the suggestion is selected via the `click` event, the input is blurred. In order to repopulate the suggestions list after a suggestion is selected via `enter`, we need to manually call `blur()` 

### Checklist

<!-- Mark these as checked by replacing [ ] with [x] -->
- [x] All tests passing
- [ ] Created tests which fail without the change (if possible) - N/A to this PR
- [ ] Extended the README / documentation, if necessary - N/A to this PR
- [x] Commits and PR follow conventions

Closes #268 and #251 