### PR TITLE
Fixed erroneous check that hid the suggestions

### DIFF
--- a/src/Geosuggest.jsx
+++ b/src/Geosuggest.jsx
@@ -101,9 +101,7 @@ class Geosuggest extends React.Component {
    * On After the input got changed
    */
   onAfterInputChange = () => {
-    if (!this.state.isSuggestsHidden) {
-      this.showSuggests();
-    }
+    this.showSuggests();
     this.props.onChange(this.state.userInput);
   };
 


### PR DESCRIPTION
<!-- Please fill out the title field according to our commit conventions -->

### Description

Fixes the suggestions disappearing after a suggest is selected and the input is edited again without first blurring & focusing again.

See https://github.com/ubilabs/react-geosuggest/issues/327 and https://github.com/ubilabs/react-geosuggest/issues/251

Steps to reproduce the bug:

1. Type an address, select any suggestion with the down arrow and press enter
2. While the input is still focused, change its content (for example erase it with backspace and type another address)
3. **Bug:** No suggestion appears

Blurring the input and focusing it again would fix the disappearing suggestions.

The bug is caused by `onAfterInputChange()` checking `state.isSuggestsHidden` before showing the suggestions.

I strongly believe this is superfluous: There is no reason to ever not show the suggestions after the input is edited.


### Checklist

<!-- Mark these as checked by replacing [ ] with [x] -->
- [x] All tests passing
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
- [x] Commits and PR follow conventions
