### PR TITLE
@diablouma @diegovillacis10 feat(minLength): add minLength prop to Ge…

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,12 @@ Default: `250`
 Sets the delay in milliseconds after typing before a request will be sent to find suggestions.
 Specify `0` if you wish to fetch suggestions after every keystroke.
 
+#### minLength
+Type: `Number`
+Default: `1`
+
+Sets a minimum length of characters before a request will be sent to find suggestions.
+
 #### highlightMatch
 Type: `Boolean`
 Default: `true`

--- a/src/Geosuggest.jsx
+++ b/src/Geosuggest.jsx
@@ -178,8 +178,14 @@ class Geosuggest extends React.Component {
     }
 
     const options = {
-      input: this.state.userInput
-    };
+        input: this.state.userInput
+      },
+      inputLength = this.state.userInput.length,
+      isShorterThanMinLength = inputLength < this.props.minLength;
+
+    if (isShorterThanMinLength) {
+      return;
+    }
 
     ['location', 'radius', 'bounds', 'types'].forEach(option => {
       if (this.props[option]) {
@@ -441,7 +447,8 @@ class Geosuggest extends React.Component {
         onSuggestMouseDown={this.onSuggestMouseDown}
         onSuggestMouseOut={this.onSuggestMouseOut}
         onSuggestSelect={this.selectSuggest}
-        renderSuggestItem={this.props.renderSuggestItem}/>;
+        renderSuggestItem={this.props.renderSuggestItem}
+        minLength={this.props.minLength}/>;
 
     return <div className={classes}>
       <div className="geosuggest__input-wrapper">

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -33,5 +33,6 @@ export default {
     'suggests': {},
     'suggestItem': {}
   },
-  ignoreTab: false
+  ignoreTab: false,
+  minLength: 1
 };

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -45,5 +45,6 @@ export default {
   }),
   ignoreTab: PropTypes.bool,
   label: PropTypes.string,
-  autoComplete: PropTypes.string
+  autoComplete: PropTypes.string,
+  minLength: PropTypes.number
 };

--- a/test/Geosuggest_spec.jsx
+++ b/test/Geosuggest_spec.jsx
@@ -593,6 +593,7 @@ describe('Component: Geosuggest', () => {
       expect(matchedText).to.have.length.of.at.least(1); // eslint-disable-line max-len
     });
   });
+
   describe('with highLightMatch', () => { // eslint-disable-line max-len
     const props = {
       suggestsClassName: 'suggests-class'
@@ -609,6 +610,47 @@ describe('Component: Geosuggest', () => {
       expect(geoSuggestItems).to.have.length.of(1);
       expect(geoSuggestItems[0].childNodes).to.have.length.of(1);
       expect(geoSuggestItems[0].childNodes[0].childNodes).to.have.length.of(6);
+    });
+  });
+
+  describe('with minLength', () => {
+    it('should not search for predictions when the input value is less than the minLength', () => { // eslint-disable-line max-len
+      const props = {
+        minLength: 5
+      };
+      render(props);
+
+      const geoSuggestInput = TestUtils.findRenderedDOMComponentWithClass(component, 'geosuggest__input'); // eslint-disable-line max-len, one-var
+      geoSuggestInput.value = 'New';
+      TestUtils.Simulate.change(geoSuggestInput);
+      TestUtils.Simulate.focus(geoSuggestInput);
+      let matchedText = TestUtils.scryRenderedDOMComponentsWithClass(component, 'geosuggest__item__matched-text'); // eslint-disable-line max-len
+      expect(matchedText).to.have.length.of(0); // eslint-disable-line max-len
+    });
+
+    it('should search for predictions when the input value is one character and minLength prop was not specified', () => { // eslint-disable-line max-len
+      render();
+
+      const geoSuggestInput = TestUtils.findRenderedDOMComponentWithClass(component, 'geosuggest__input'); // eslint-disable-line max-len, one-var
+      geoSuggestInput.value = 'New';
+      TestUtils.Simulate.change(geoSuggestInput);
+      TestUtils.Simulate.focus(geoSuggestInput);
+      let matchedText = TestUtils.scryRenderedDOMComponentsWithClass(component, 'geosuggest__item__matched-text'); // eslint-disable-line max-len
+      expect(matchedText).to.have.length.of.at.least(1); // eslint-disable-line max-len
+    });
+
+    it('should search for predictions when the input value is greater than the minLength prop specified', () => { // eslint-disable-line max-len
+      const props = {
+        minLength: 3
+      };
+      render(props);
+
+      const geoSuggestInput = TestUtils.findRenderedDOMComponentWithClass(component, 'geosuggest__input'); // eslint-disable-line max-len, one-var
+      geoSuggestInput.value = 'New York';
+      TestUtils.Simulate.change(geoSuggestInput);
+      TestUtils.Simulate.focus(geoSuggestInput);
+      let matchedText = TestUtils.scryRenderedDOMComponentsWithClass(component, 'geosuggest__item__matched-text'); // eslint-disable-line max-len
+      expect(matchedText).to.have.length.of.at.least(1); // eslint-disable-line max-len
     });
   });
 });


### PR DESCRIPTION
feat(minLength): add minLength prop to Geosuggest component

### Description

As part of our work we need to specify a min length for the search term before starting the search against google, so we added a new prop called 'minLenght' to specify the min length that the input should have before starting the search.

### Checklist

<!-- Mark these as checked by replacing [ ] with [x] -->
- [x] All tests passing
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
- [x] Commits and PR follow conventions
