### PR TITLE
fix(Geosuggest): clear suggestion on empty input

### DIFF
--- a/example/src/app.js
+++ b/example/src/app.js
@@ -5,13 +5,6 @@ import ReactDOM from 'react-dom';
 import Geosuggest from '../../src/Geosuggest';
 
 class App extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      selectedSuggest: null
-    };
-    this.onSuggestSelect = this.onSuggestSelect.bind(this);
-  }
   /**
    * When the input receives focus
    */
@@ -41,9 +34,6 @@ class App extends React.Component {
    */
   onSuggestSelect(suggest) {
     console.log(suggest); // eslint-disable-line
-    this.setState({
-      selectedSuggest: suggest
-    });
   }
 
   /**
@@ -76,9 +66,6 @@ class App extends React.Component {
           onSuggestNoResults={this.onSuggestNoResults}
           location={new google.maps.LatLng(53.558572, 9.9278215)}
           radius="20" />
-        <div>
-          {this.state.selectedSuggest && this.state.selectedSuggest.label}
-        </div>
       </div>
     );
   }

--- a/example/src/app.js
+++ b/example/src/app.js
@@ -5,6 +5,13 @@ import ReactDOM from 'react-dom';
 import Geosuggest from '../../src/Geosuggest';
 
 class App extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      selectedSuggest: null
+    };
+    this.onSuggestSelect = this.onSuggestSelect.bind(this);
+  }
   /**
    * When the input receives focus
    */
@@ -34,6 +41,9 @@ class App extends React.Component {
    */
   onSuggestSelect(suggest) {
     console.log(suggest); // eslint-disable-line
+    this.setState({
+      selectedSuggest: suggest
+    });
   }
 
   /**
@@ -66,6 +76,9 @@ class App extends React.Component {
           onSuggestNoResults={this.onSuggestNoResults}
           location={new google.maps.LatLng(53.558572, 9.9278215)}
           radius="20" />
+        <div>
+          {this.state.selectedSuggest && this.state.selectedSuggest.label}
+        </div>
       </div>
     );
   }

--- a/src/Geosuggest.jsx
+++ b/src/Geosuggest.jsx
@@ -94,6 +94,9 @@ class Geosuggest extends React.Component {
    * @param {String} userInput The input value of the user
    */
   onInputChange = userInput => {
+    if (!userInput) {
+      this.props.onSuggestSelect();
+    }
     this.setState({userInput}, this.onAfterInputChange);
   };
 

--- a/test/Geosuggest_spec.jsx
+++ b/test/Geosuggest_spec.jsx
@@ -113,6 +113,26 @@ describe('Component: Geosuggest', () => {
       expect(onSuggestSelect.calledOnce).to.be.true; // eslint-disable-line no-unused-expressions, max-len
     });
 
+    it('should call `onSuggestSelect` when we clear out the selected city', () => { // eslint-disable-line max-len
+      const geoSuggestInput = TestUtils.findRenderedDOMComponentWithClass(component, 'geosuggest__input'); // eslint-disable-line max-len
+      geoSuggestInput.value = 'New';
+      TestUtils.Simulate.change(geoSuggestInput);
+      TestUtils.Simulate.keyDown(geoSuggestInput, {
+        key: 'keyDown',
+        keyCode: 40,
+        which: 40
+      });
+      TestUtils.Simulate.keyDown(geoSuggestInput, {
+        key: 'Enter',
+        keyCode: 13,
+        which: 13
+      });
+      expect(onSuggestSelect.calledOnce).to.be.true; // eslint-disable-line no-unused-expressions, max-len
+      geoSuggestInput.value = '';
+      TestUtils.Simulate.change(geoSuggestInput);
+      expect(onSuggestSelect.calledWithExactly()).to.be.true; // eslint-disable-line no-unused-expressions, max-len
+    });
+
     it('should call `onActivateSuggest` when we key down to a suggestion', () => { // eslint-disable-line max-len
       const geoSuggestInput = TestUtils.findRenderedDOMComponentWithClass(component, 'geosuggest__input'); // eslint-disable-line max-len
       geoSuggestInput.value = 'New';


### PR DESCRIPTION
<!-- Please fill out the title field according to our commit conventions -->

### Description
This fixes #201 
When a place is selected and then cleared by erasing the input field, it should also clear out the previous selection from the model.
My fix is to call `onSuggestSelect` with `undefined` so the previously selected place is cleared out
Also added the selected place to the example UI for easy verification

### Checklist

<!-- Mark these as checked by replacing [ ] with [x] -->
- [ ] All tests passing
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
- [ ] Commits and PR follow conventions