### PR TITLE
Replacing legacy shallow-compare with PureComponent

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,12 +14,11 @@
     "url": "https://github.com/ubilabs/react-geosuggest/issues"
   },
   "peerDependencies": {
-    "react": "^0.14.0 || ^15.0.0"
+    "react": "^0.15.0"
   },
   "dependencies": {
     "classnames": "^2.2.3",
-    "lodash.debounce": "^4.0.6",
-    "react-addons-shallow-compare": "^15.5.2"
+    "lodash.debounce": "^4.0.6"
   },
   "devDependencies": {
     "babel-cli": "^6.6.5",

--- a/src/input.jsx
+++ b/src/input.jsx
@@ -1,5 +1,4 @@
 import React from 'react'; // eslint-disable-line no-unused-vars
-import shallowCompare from 'react-addons-shallow-compare';
 import classnames from 'classnames';
 
 import filterInputAttributes from './filter-input-attributes';
@@ -9,17 +8,7 @@ import filterInputAttributes from './filter-input-attributes';
  * @param {Object} props The component's props
  * @return {JSX} The icon component.
  */
-class Input extends React.Component {
-  /**
-   * Whether or not the component should update
-   * @param {Object} nextProps The new properties
-   * @param {Object} nextState The new state
-   * @return {Boolean} Update or not?
-   */
-  shouldComponentUpdate(nextProps, nextState) {
-    return shallowCompare(this, nextProps, nextState);
-  }
-
+class Input extends React.PureComponent {
   /**
    * When the input got changed
    */

--- a/src/suggest-list.jsx
+++ b/src/suggest-list.jsx
@@ -1,5 +1,4 @@
 import React from 'react'; // eslint-disable-line no-unused-vars
-import shallowCompare from 'react-addons-shallow-compare';
 import classnames from 'classnames';
 import SuggestItem from './suggest-item';
 
@@ -8,17 +7,7 @@ import SuggestItem from './suggest-item';
  * @param {Object} props The component's props
  * @return {JSX} The icon component.
  */
-export default class SuggestList extends React.Component {
-  /**
-   * Whether or not the component should update
-   * @param {Object} nextProps The new properties
-   * @param {Object} nextState The new state
-   * @return {Boolean} Update or not?
-   */
-  shouldComponentUpdate(nextProps, nextState) {
-    return shallowCompare(this, nextProps, nextState);
-  }
-
+export default class SuggestList extends React.PureComponent {
   /**
    * Whether or not it is hidden
    * @return {Boolean} Hidden or not?


### PR DESCRIPTION
### Description

Fixes #329 
This change is not retro compatible, So you cant use it with react < 0.15.3.
But React-addons-shallow-compare is a legacy react code.
Anyways if some wants to keep using 0.14.x react version can use older version of this project.

### Checklist

- [X ] All tests passing
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
- [ X] Commits and PR follow conventions
