### PR TITLE
feat(ignoreEnter): add new prop to disable enter key.

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,12 @@ Default: `false`
 
 When the tab key is pressed, the `onSelect` handler is invoked. Set to true to not invoke `onSelect` on tab press.
 
+#### ignoreEnter
+Type: `Boolean`
+Default: `false`
+
+When the enter key is pressed, the `onSelect` handler is invoked. Set to true to not invoke `onSelect` on enter press.
+
 #### queryDelay
 Type: `Number`
 Default: `250`

--- a/src/Geosuggest.jsx
+++ b/src/Geosuggest.jsx
@@ -423,8 +423,9 @@ class Geosuggest extends React.Component {
       input = <Input className={this.props.inputClassName}
         ref={i => this.input = i}
         value={this.state.userInput}
-        ignoreEnter={!this.state.isSuggestsHidden}
+        submitOnEnter={!this.state.isSuggestsHidden}
         ignoreTab={this.props.ignoreTab}
+        ignoreEnter={this.props.ignoreEnter}
         style={this.props.style.input}
         onChange={this.onInputChange}
         onFocus={this.onInputFocus}

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -35,5 +35,6 @@ export default {
     'suggestItem': {}
   },
   ignoreTab: false,
+  ignoreEnter: false,
   minLength: 1
 };

--- a/src/input.jsx
+++ b/src/input.jsx
@@ -74,11 +74,14 @@ class Input extends React.Component {
         }
         break;
       case 13: // ENTER
-        if (this.props.ignoreEnter) {
+        if (this.props.submitOnEnter) {
           event.preventDefault();
         }
 
-        this.props.onSelect();
+        if (!this.props.ignoreEnter) {
+          this.props.onSelect();
+        }
+
         break;
       case 9: // TAB
         if (!this.props.ignoreTab) {

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -45,6 +45,7 @@ export default {
     suggestItem: PropTypes.object
   }),
   ignoreTab: PropTypes.bool,
+  ignoreEnter: PropTypes.bool,
   label: PropTypes.string,
   autoComplete: PropTypes.string,
   minLength: PropTypes.number

--- a/test/Geosuggest_spec.jsx
+++ b/test/Geosuggest_spec.jsx
@@ -361,6 +361,21 @@ describe('Component: Geosuggest', () => {
     });
   });
 
+  describe('with enter ignored', () => {
+    beforeEach(() => render({ignoreEnter: true}));
+
+    it('should not call onSuggestSelect on enter', () => {
+      const geoSuggestInput = TestUtils.findRenderedDOMComponentWithClass(component, 'geosuggest__input'); // eslint-disable-line max-len
+      geoSuggestInput.value = 'New';
+      TestUtils.Simulate.keyDown(geoSuggestInput, {
+        key: 'Tab',
+        keyCode: 13,
+        which: 13
+      });
+      expect(onSuggestSelect.calledOnce).to.be.false; // eslint-disable-line no-unused-expressions, max-len
+    });
+  });
+
   describe('with fixtures', () => {
     const fixtures = [
       {label: 'New York', location: {lat: 40.7033127, lng: -73.979681}},


### PR DESCRIPTION
Closes #345.

Rename current internal variable named "ignoreEnter" to "submitOnEnter".

Add a new prop type named "ignoreEnter" which can accept
boolean value and default value is false.
If set to true then Input component will ignore Enter key.

- [x] All tests passing
- [x] Created tests which fail without the change
- [x] Extended the README / documentation
- [x] Commits and PR follow conventions
