### PR TITLE
fix(geosuggest) - call onChange callback first

### DIFF
--- a/src/Geosuggest.jsx
+++ b/src/Geosuggest.jsx
@@ -104,8 +104,8 @@ class Geosuggest extends React.Component {
    * On After the input got changed
    */
   onAfterInputChange = () => {
-    this.showSuggests();
     this.props.onChange(this.state.userInput);
+    this.showSuggests();
   };
 
   /**

--- a/test/Geosuggest_spec.jsx
+++ b/test/Geosuggest_spec.jsx
@@ -431,6 +431,26 @@ describe('Component: Geosuggest', () => {
       const suggestItems = TestUtils.scryRenderedDOMComponentsWithClass(component, 'geosuggest__item'); // eslint-disable-line max-len, one-var
       expect(suggestItems.length).to.equal(2);
     });
+
+    describe('changing the input value', () => {
+      const props = {
+        skipSuggest: sinon.spy(),
+        initialValue: 'n',
+        fixtures
+      };
+
+      beforeEach(() => render(props));
+
+      it('should call `onChange` before skipSuggest', () => {
+        const geoSuggestInput = TestUtils.findRenderedDOMComponentWithClass(
+          component,
+          'geosuggest__input'
+        );
+        geoSuggestInput.value = '';
+        TestUtils.Simulate.change(geoSuggestInput);
+        expect(onChange.calledBefore(props.skipSuggest)).to.be.true; // eslint-disable-line no-unused-expressions, max-len
+      });
+    });
   });
 
   describe('with autoActivateFirstSuggest enabled', () => {


### PR DESCRIPTION
onChange callback can be used by parent component to get the user entered value and use this later in skipSuggest or renderSuggestItem to manipulate the suggestions.
Calling onChange at the end makes it hard for parent component to use the correct value entered by the user.

fixes #376



### Checklist

<!-- Mark these as checked by replacing [ ] with [x] -->
- [x] All tests passing
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
- [x] Commits and PR follow conventions
