### PR TITLE
fix(autoComplete prop default value): Change default value from off (which Chrome and other modern browsers ignore) to nope which generates the expected result

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ Additional `className` to add when a suggestion item is active.
 
 #### autoComplete
 Type: `String`,
-Default: `off`
+Default: `nope`
 
 Autocomplete input attribute.
 

--- a/src/input.jsx
+++ b/src/input.jsx
@@ -143,7 +143,7 @@ Input.defaultProps = {
   ignoreTab: false,
   onKeyDown: () => {},
   onKeyPress: () => {},
-  autoComplete: 'off'
+  autoComplete: 'nope'
 };
 
 export default Input;


### PR DESCRIPTION
### Description

Fixes a bug where the native browser's autocomplete drawer/options display on top of the react-geosuggest autocomplete drawer/options making it difficult and in some cases impossible to select a desired option. Although users of this library can overwrite the current autoComplete default value of `off` I feel a default value that gives the user what they expect out of the box is better. That way users won't have to search the internet to find a default value override that will work as listed [here](https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion#Disabling_autocompletion) (look for the `nope` suggestion).

Here's a visual of the issue this PR will fix for both Chrome (tested v66.0.3359.139) and Safari (tested v11.1) at minimum:

#### Chrome (with default value of `off`)
![chrome](https://user-images.githubusercontent.com/9529/39788904-821c3b80-52e1-11e8-8519-224ec58a4d04.gif)

#### Safari (with default value of `off`)
![safari](https://user-images.githubusercontent.com/9529/39789025-2c246ef4-52e2-11e8-82cf-235c574569d0.gif)

### Checklist

<!-- Mark these as checked by replacing [ ] with [x] -->
- [x] All tests passing
- [ ] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
- [x] Commits and PR follow conventions
