### PR TITLE
fix unit test compilation errors

### DIFF
--- a/test/Geosuggest_spec.tsx
+++ b/test/Geosuggest_spec.tsx
@@ -347,16 +347,16 @@ describe('Component: Geosuggest', () => {
 
     it('should have the focus after calling `focus`', () => {
       component.focus();
-      expect(document.activeElement.classList.contains('geosuggest__input')).to
+      expect(document.activeElement!.classList.contains('geosuggest__input')).to
         .be.true;
     });
 
     it('should not have the focus after calling `blur`', () => {
       component.focus();
-      expect(document.activeElement.classList.contains('geosuggest__input')).to
+      expect(document.activeElement!.classList.contains('geosuggest__input')).to
         .be.true;
       component.blur();
-      expect(document.activeElement.classList.contains('geosuggest__input')).to
+      expect(document.activeElement!.classList.contains('geosuggest__input')).to
         .be.false;
     });
 


### PR DESCRIPTION
### Description

The unit tests were failing to run due to compilation errors that said, `"Object is possibly 'null'"`

### Checklist

<!-- Mark these as checked by replacing [ ] with [x] -->
- [x] All tests passing
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
- [x] Commits and PR follow conventions
