### PR TITLE
Allow to customize/extend fixture properties

### DIFF
--- a/src/Geosuggest.tsx
+++ b/src/Geosuggest.tsx
@@ -347,7 +347,7 @@ export default class extends React.Component<IProps, IState> {
               length: userInput.length,
               offset: fixture.label.indexOf(userInput)
             },
-            placeId: fixture.label
+            placeId: fixture.placeId
           });
         }
       });

--- a/src/Geosuggest.tsx
+++ b/src/Geosuggest.tsx
@@ -339,6 +339,7 @@ export default class extends React.Component<IProps, IState> {
           fixturesSearched++;
 
           suggests.push({
+            ...fixture,
             className: fixture.className,
             isFixture: true,
             label: fixture.label,
@@ -347,7 +348,7 @@ export default class extends React.Component<IProps, IState> {
               length: userInput.length,
               offset: fixture.label.indexOf(userInput)
             },
-            placeId: fixture.placeId
+            placeId: fixture.placeId || fixture.label
           });
         }
       });

--- a/src/Geosuggest.tsx
+++ b/src/Geosuggest.tsx
@@ -340,10 +340,7 @@ export default class extends React.Component<IProps, IState> {
 
           suggests.push({
             ...fixture,
-            className: fixture.className,
             isFixture: true,
-            label: fixture.label,
-            location: fixture.location,
             matchedSubstrings: {
               length: userInput.length,
               offset: fixture.label.indexOf(userInput)

--- a/src/types/fixture.d.ts
+++ b/src/types/fixture.d.ts
@@ -3,7 +3,7 @@
  */
 export default interface IFixture {
   readonly label: string;
-  readonly placeId: string;
+  readonly placeId?: string;
   readonly location?: {
     lat: number;
     lng: number;

--- a/src/types/fixture.d.ts
+++ b/src/types/fixture.d.ts
@@ -3,6 +3,7 @@
  */
 export default interface IFixture {
   readonly label: string;
+  readonly placeId: string;
   readonly location?: {
     lat: number;
     lng: number;

--- a/test/Geosuggest_spec.tsx
+++ b/test/Geosuggest_spec.tsx
@@ -797,6 +797,45 @@ describe('Component: Geosuggest', () => {
     });
   });
 
+  describe('with updateSuggests', () => {
+    const props = {
+      fixtures: [
+        {
+          'placeId': '123456789',
+          'label': 'Location1',
+          'isFixture':true,
+          'location': {'lat':46,'lng':-71},
+          'locationId': 123456789,
+          'className': 'fixture'
+        },
+        {
+          'label': 'Location2',
+          'isFixture':true,
+          'location': {'lat':46,'lng':-71},
+          'locationId': 123456789,
+          'className': 'fixture'
+        }
+      ]
+    };
+
+    beforeEach(() => { 
+      render(props);
+      component.updateSuggests();
+    });
+
+    it('should set suggest.placeId to fixture.placeId if fixture.placeId is defined', () => {
+      expect(component.state.suggests[0].placeId).to.equal(props.fixtures[0].placeId);
+    });
+
+    it('should set suggest.placeId to fixture.label if fixture.placeId is not defined', () => {
+      expect(component.state.suggests[1].placeId).to.equal(props.fixtures[1].label);
+    });
+
+    it('should set suggest.locationId to fixture.locationId if fixture.locationId is defined', () => {
+      expect(component.state.suggests[0].locationId).to.equal(props.fixtures[0].locationId);
+    });
+  });
+
   describe('with renderSuggestItem with custom fixture attributes', () => {
     const fixtures = [
       {


### PR DESCRIPTION
<!-- Please fill out the title field according to our commit conventions -->

### Description
We at Uberall.com had been running into issues with the original React GeoSuggest plugin, because sometimes fixtures were not having unique `placeIds`.
Since the respective `placeId` was also used as a React `key`, the React diffing algorithm wasn't working properly due to duplicate `keys`. 
Our solution was to have two separate keys for each fixture: 'label' and 'placeId', where the `label` was used for display, and `placeId` for the `key`. This ensures that each fixtures has its unique `key`.

We also made another custom change by adding a fixture.locationId property to the resulting `suggest`. It enables us to reuse properties passed to the fixture.

### Checklist

<!-- Mark these as checked by replacing [ ] with [x] -->
- [x] All tests passing
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
- [x] Commits and PR follow conventions
