### PR TITLE
feat: use first suggest on selectSuggest when autoActivateFirstSuggest 

### DIFF
--- a/src/Geosuggest.tsx
+++ b/src/Geosuggest.tsx
@@ -455,11 +455,19 @@ export default class extends React.Component<IProps, IState> {
    * When an item got selected
    */
   selectSuggest(suggestToSelect: ISuggest | null) {
-    const suggest: ISuggest = suggestToSelect || {
+    let suggest: ISuggest = suggestToSelect || {
       isFixture: false,
       label: this.state.userInput,
       placeId: this.state.userInput
     };
+
+    if (
+      !suggestToSelect &&
+      this.props.autoActivateFirstSuggest &&
+      this.state.suggests.length > 0
+    ) {
+      suggest = this.state.suggests[0];
+    }
 
     this.setState({
       isSuggestsHidden: true,

--- a/test/Geosuggest_spec.tsx
+++ b/test/Geosuggest_spec.tsx
@@ -653,6 +653,32 @@ describe('Component: Geosuggest', () => {
     });
   });
 
+  describe('with autoActivateFirstSuggest and fixtures enabled', () => {
+    const props = {
+      autoActivateFirstSuggest: true,
+      fixtures: [
+        {label: 'New Yorrrrk'}
+      ]
+    };
+
+    beforeEach(() => render(props));
+
+    it('should select the first suggest on `selectSuggest`', () => {
+      const geoSuggestInput = TestUtils.findRenderedDOMComponentWithClass(
+        component,
+        'geosuggest__input'
+      ) as HTMLInputElement;
+      geoSuggestInput.value = 'New';
+      TestUtils.Simulate.change(geoSuggestInput);
+
+      component.selectSuggest();
+
+      expect(onSuggestSelect.calledWithMatch((value: any) => {
+        return value.label === props.fixtures[0].label;
+      })).to.be.true;
+    });
+  });
+
   describe('with label and id props', () => {
     const props = {
       id: 'geosuggest-id',


### PR DESCRIPTION
Closes #423

<!-- Please fill out the title field according to our commit conventions -->

### Description

Use the first suggest when `autoActivateFirstSuggest` is true and `selectSuggest` is called.

### Checklist

<!-- Mark these as checked by replacing [ ] with [x] -->
- [x] All tests passing
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
- [x] Commits and PR follow conventions
