### PR TITLE
Add a11y attributes to make suggestions readable by screen readers

### DIFF
--- a/src/Geosuggest.tsx
+++ b/src/Geosuggest.tsx
@@ -74,6 +74,11 @@ export default class extends React.Component<IProps, IState> {
   input: Input | null = null;
 
   /**
+   * Id for the suggestions list
+   */
+  listId: string;
+
+  /**
    * The constructor. Sets the initial state.
    */
   constructor(props: IProps) {
@@ -100,6 +105,9 @@ export default class extends React.Component<IProps, IState> {
     this.onSuggestNoResults = this.onSuggestNoResults.bind(this);
     this.hideSuggests = this.hideSuggests.bind(this);
     this.selectSuggest = this.selectSuggest.bind(this);
+    this.listId = `geosuggest__list_${Math.random()
+      .toString(16)
+      .slice(2)}`;
 
     if (props.queryDelay) {
       this.onAfterInputChange = debounce(
@@ -594,6 +602,9 @@ export default class extends React.Component<IProps, IState> {
         onPrev={this.onPrev}
         onSelect={this.onSelect}
         onEscape={this.hideSuggests}
+        isSuggestsHidden={this.state.isSuggestsHidden}
+        activeSuggest={this.state.activeSuggest}
+        listId={this.listId}
         {...attributes}
       />
     );
@@ -615,6 +626,7 @@ export default class extends React.Component<IProps, IState> {
         onSuggestMouseOut={this.onSuggestMouseOut}
         onSuggestSelect={this.selectSuggest}
         renderSuggestItem={this.props.renderSuggestItem}
+        listId={this.listId}
       />
     );
 

--- a/src/input.tsx
+++ b/src/input.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import classnames from 'classnames';
 
 import filterInputAttributes from './filter-input-attributes';
+import ISuggest from './types/suggest';
 
 interface IProps {
   readonly value: string;
@@ -11,6 +12,9 @@ interface IProps {
   readonly ignoreTab?: boolean;
   readonly style?: any;
   readonly autoComplete?: string;
+  readonly isSuggestsHidden: boolean;
+  readonly activeSuggest: ISuggest | null;
+  readonly listId: string;
   readonly onChange: (value: string) => void;
   readonly onSelect: () => void;
   readonly onKeyDown?: (event: React.KeyboardEvent) => void;
@@ -31,8 +35,11 @@ export default class extends React.PureComponent<IProps, {}> {
    * Default values for the properties
    */
   static defaultProps: IProps = {
+    activeSuggest: null,
     autoComplete: 'nope',
     className: '',
+    isSuggestsHidden: true,
+    listId: '',
     onBlur: () => {},
     onChange: () => {},
     onEscape: () => {},
@@ -154,6 +161,14 @@ export default class extends React.PureComponent<IProps, {}> {
         onKeyPress={this.props.onKeyPress}
         onFocus={this.props.onFocus}
         onBlur={this.props.onBlur}
+        role="combobox"
+        aria-expanded={!this.props.isSuggestsHidden}
+        aria-activedescendant={
+          this.props.activeSuggest
+            ? this.props.activeSuggest.placeId
+            : undefined
+        }
+        aria-owns={this.props.listId}
       />
     );
   }

--- a/src/suggest-item.tsx
+++ b/src/suggest-item.tsx
@@ -161,7 +161,10 @@ export default class extends React.PureComponent<IProps, {}> {
         style={this.props.style}
         onMouseDown={this.props.onMouseDown}
         onMouseOut={this.props.onMouseOut}
-        onClick={this.onClick}>
+        onClick={this.onClick}
+        role="option"
+        aria-selected={this.props.isActive}
+        id={suggest.placeId}>
         {content}
       </li>
     );

--- a/src/suggest-list.tsx
+++ b/src/suggest-list.tsx
@@ -15,6 +15,7 @@ interface IProps {
   readonly suggestItemStyle: any;
   readonly userInput: string;
   readonly isHighlightMatch: boolean;
+  readonly listId: string;
   readonly onSuggestNoResults: () => void;
   readonly renderSuggestItem?: (
     suggest: ISuggest,
@@ -64,7 +65,11 @@ export default class extends React.PureComponent<IProps, {}> {
     );
 
     return (
-      <ul className={classes} style={this.props.style}>
+      <ul
+        className={classes}
+        style={this.props.style}
+        role="listbox"
+        id={this.props.listId}>
         {this.props.suggests.map(suggest => {
           const isActive =
             (this.props.activeSuggest &&

--- a/test/Geosuggest_spec.tsx
+++ b/test/Geosuggest_spec.tsx
@@ -1010,4 +1010,57 @@ describe('Component: Geosuggest', () => {
       expect(matchedText).to.have.lengthOf.at.least(1);
     });
   });
+
+  describe('accessibility', () => {
+    let geoSuggestInput: HTMLInputElement;
+    beforeEach(() => {
+      render();
+
+      geoSuggestInput = TestUtils.findRenderedDOMComponentWithClass(
+        component,
+        'geosuggest__input'
+      ) as HTMLInputElement;
+      geoSuggestInput.value = 'New';
+      TestUtils.Simulate.change(geoSuggestInput);
+    });
+
+    it('should add aria-selected for the active suggestion', () => {
+      const suggests = TestUtils.scryRenderedDOMComponentsWithClass(
+        component,
+        'geosuggest__item'
+      );
+      expect(suggests[0].getAttribute('aria-selected')).to.equal('false');
+
+      TestUtils.Simulate.focus(geoSuggestInput);
+      TestUtils.Simulate.keyDown(geoSuggestInput, {
+        key: 'keyDown',
+        keyCode: 40,
+        which: 40
+      });
+      expect(suggests[0].getAttribute('aria-selected')).to.equal('true');
+    });
+
+    it('should set aria-expanded to false when suggestions are hidden', () => {
+      expect(geoSuggestInput.getAttribute('aria-expanded')).to.equal('true');
+
+      TestUtils.Simulate.keyDown(geoSuggestInput, {
+        key: 'Enter',
+        keyCode: 13,
+        which: 13
+      });
+
+      expect(geoSuggestInput.getAttribute('aria-expanded')).to.equal('false');
+    });
+
+    it('should have aria-owns attribute set to the list id', () => {
+      const suggests = TestUtils.scryRenderedDOMComponentsWithClass(
+        component,
+        'geosuggest__suggests'
+      );
+
+      const listId = suggests[0].getAttribute('id');
+
+      expect(geoSuggestInput.getAttribute('aria-owns')).to.equal(listId);
+    });
+  });
 });


### PR DESCRIPTION
### Description

Fixes a bug where geosuggest suggestions were not read aloud by screen readers

### Checklist

- [x] All tests passing
- [x] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
- [x] Commits and PR follow conventions
