### PR TITLE
fix: warnings for componentWillReceiveProps and componentWillMount

### DIFF
--- a/src/Geosuggest.tsx
+++ b/src/Geosuggest.tsx
@@ -112,9 +112,9 @@ export default class extends React.Component<IProps, IState> {
   /**
    * Change inputValue if prop changes
    */
-  componentWillReceiveProps(props: IProps) {
-    if (this.props.initialValue !== props.initialValue) {
-      this.setState({userInput: props.initialValue || ''});
+  componentDidUpdate(prevProps: IProps): void {
+    if (prevProps.initialValue !== this.props.initialValue) {
+      this.setState({userInput: this.props.initialValue || ''});
     }
   }
 

--- a/src/Geosuggest.tsx
+++ b/src/Geosuggest.tsx
@@ -123,7 +123,7 @@ export default class extends React.Component<IProps, IState> {
    * Google api sdk object will be obtained and cached as a instance property.
    * Necessary objects of google api will also be determined and saved.
    */
-  componentWillMount() {
+  componentDidMount() {
     if (typeof window === 'undefined') {
       return;
     }

--- a/src/suggest-item.tsx
+++ b/src/suggest-item.tsx
@@ -90,8 +90,8 @@ export default class extends React.PureComponent<IProps, {}> {
   /**
    * Checking if item just became active and scrolling if needed.
    */
-  componentWillReceiveProps(nextProps: IProps): void {
-    if (nextProps.isActive && !this.props.isActive) {
+  componentDidUpdate(prevProps: IProps): void {
+    if (!prevProps.isActive && this.props.isActive) {
       this.scrollIfNeeded();
     }
   }

--- a/src/suggest-list.tsx
+++ b/src/suggest-list.tsx
@@ -39,9 +39,9 @@ export default class extends React.PureComponent<IProps, {}> {
   /**
    * There are new properties available for the list
    */
-  componentWillReceiveProps(nextProps: IProps) {
-    if (nextProps.suggests !== this.props.suggests) {
-      if (nextProps.suggests.length === 0) {
+  componentDidUpdate(prevProps: IProps) {
+    if (prevProps.suggests !== this.props.suggests) {
+      if (this.props.suggests.length === 0) {
         this.props.onSuggestNoResults();
       }
     }


### PR DESCRIPTION
### Description

Fixes deprecation warnings from react. 

The ones for `componentWillReceiveProps`:

```
react-dom.development.js:12466 Warning: componentWillReceiveProps has been renamed, and is not recommended for use. See https://fb.me/react-unsafe-component-lifecycles for details.

* Move data fetching code or side effects to componentDidUpdate.
* If you're updating state whenever props change, refactor your code to use memoization techniques or move it to static getDerivedStateFromProps. Learn more at: https://fb.me/react-derived-state
* Rename componentWillReceiveProps to UNSAFE_componentWillReceiveProps to suppress this warning in non-strict mode. In React 17.x, only the UNSAFE_ name will work. To rename all deprecated lifecycles to their new names, you can run `npx react-codemod rename-unsafe-lifecycles` in your project source folder.

Please update the following components: default_1, default_1$1
```

And the one `componentWillMount`:

```
Warning: componentWillMount has been renamed, and is not recommended for use. See https://fb.me/react-unsafe-component-lifecycles for details.

* Move code with side effects to componentDidMount, and set initial state in the constructor.
* Rename componentWillMount to UNSAFE_componentWillMount to suppress this warning in non-strict mode. In React 17.x, only the UNSAFE_ name will work. To rename all deprecated lifecycles to their new names, you can run `npx react-codemod rename-unsafe-lifecycles` in your project source folder.

Please update the following components: default_1$1
```

### Checklist

- [x] All tests passing
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
- [x] Commits and PR follow conventions
