### PR TITLE
Add `data-id` to allowed additional attributes

### DIFF
--- a/src/filter-input-attributes.ts
+++ b/src/filter-input-attributes.ts
@@ -6,6 +6,7 @@ const allowedAttributes: string[] = [
   'autoComplete',
   'autoCorrect',
   'autoFocus',
+  'data-id',
   'disabled',
   'form',
   'formAction',


### PR DESCRIPTION
For the geosuggest input, allow the attribute `data-id` to be added to the component.

<!-- Please fill out the title field according to our commit conventions -->

### Description

Fixes a bug where '...' happened when '...'

### Checklist

<!-- Mark these as checked by replacing [ ] with [x] -->
- [ ] All tests passing
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
- [ ] Commits and PR follow conventions
