### PR TITLE
Stop bundling classnames and lodash.debounce in module

### DIFF
--- a/rollup.module.config.js
+++ b/rollup.module.config.js
@@ -38,5 +38,9 @@ export default {
       file: 'module/Geosuggest.esm.js',
       format: 'esm'
     }
+  ],
+  external: [
+    'classnames',
+    'lodash.debounce'
   ]
 };


### PR DESCRIPTION
Fix https://github.com/ubilabs/react-geosuggest/issues/451

Because they are defined as `dependencies` they should not be bundled.
