### PR TITLE
fix: use a not random id for the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,12 @@ Default: `''`
 
 An initial value for the input, when you want to prefill the suggest.
 
+#### id
+Type: `String`
+Default: `''`
+
+Define an ID for the geosuggest. Needed when there are multiple instances on a page.
+
 #### className
 Type: `String`
 Default: `''`

--- a/src/Geosuggest.tsx
+++ b/src/Geosuggest.tsx
@@ -108,7 +108,7 @@ export default class extends React.Component<IProps, IState> {
     this.onSuggestNoResults = this.onSuggestNoResults.bind(this);
     this.hideSuggests = this.hideSuggests.bind(this);
     this.selectSuggest = this.selectSuggest.bind(this);
-    this.listId = `geosuggest__list_${Math.random().toString(16).slice(2)}`;
+    this.listId = `geosuggest__list${props.id ? `--${props.id}` : ''}`;
 
     if (props.queryDelay) {
       this.onAfterInputChange = debounce(
@@ -648,7 +648,7 @@ export default class extends React.Component<IProps, IState> {
     );
 
     return (
-      <div className={classes}>
+      <div className={classes} id={this.props.id}>
         <div className="geosuggest__input-wrapper">
           {shouldRenderLabel && (
             <label className="geosuggest__label" htmlFor={attributes.id}>

--- a/src/Geosuggest.tsx
+++ b/src/Geosuggest.tsx
@@ -600,7 +600,6 @@ export default class extends React.Component<IProps, IState> {
     const classes = classnames('geosuggest', this.props.className, {
       'geosuggest--loading': this.state.isLoading
     });
-    const shouldRenderLabel = this.props.label && attributes.id;
     const input = (
       <Input
         className={this.props.inputClassName}
@@ -621,6 +620,8 @@ export default class extends React.Component<IProps, IState> {
         onEscape={this.hideSuggests}
         isSuggestsHidden={this.state.isSuggestsHidden}
         activeSuggest={this.state.activeSuggest}
+        label={this.props.label}
+        id={this.props.id}
         listId={this.listId}
         {...attributes}
       />
@@ -649,14 +650,7 @@ export default class extends React.Component<IProps, IState> {
 
     return (
       <div className={classes} id={this.props.id}>
-        <div className="geosuggest__input-wrapper">
-          {shouldRenderLabel && (
-            <label className="geosuggest__label" htmlFor={attributes.id}>
-              {this.props.label}
-            </label>
-          )}
-          {input}
-        </div>
+        <div className="geosuggest__input-wrapper">{input}</div>
         <div className="geosuggest__suggests-wrapper">{suggestionsList}</div>
       </div>
     );

--- a/src/filter-input-attributes.ts
+++ b/src/filter-input-attributes.ts
@@ -14,7 +14,6 @@ const allowedAttributes: string[] = [
   'formNoValidate',
   'formTarget',
   'height',
-  'id',
   'inputMode',
   'maxLength',
   'name',

--- a/src/input.tsx
+++ b/src/input.tsx
@@ -7,6 +7,7 @@ import ISuggest from './types/suggest';
 interface IProps {
   readonly value: string;
   readonly className?: string;
+  readonly id?: string;
   readonly doNotSubmitOnEnter?: boolean;
   readonly ignoreEnter?: boolean;
   readonly ignoreTab?: boolean;
@@ -16,6 +17,7 @@ interface IProps {
   readonly isSuggestsHidden: boolean;
   readonly activeSuggest: ISuggest | null;
   readonly listId: string;
+  readonly label?: string;
   readonly onChange: (value: string) => void;
   readonly onSelect: () => void;
   readonly onKeyDown?: (event: React.KeyboardEvent) => void;
@@ -149,34 +151,43 @@ export default class Input extends React.PureComponent<IProps, {}> {
   render(): JSX.Element {
     const attributes = filterInputAttributes(this.props);
     const classes = classnames('geosuggest__input', this.props.className);
+    const shouldRenderLabel = this.props.label && this.props.id;
 
     if (!attributes.tabIndex) {
       attributes.tabIndex = 0;
     }
 
     return (
-      <input
-        className={classes}
-        ref={(i): HTMLInputElement | null => (this.input = i)}
-        type="text"
-        {...attributes}
-        value={this.props.value}
-        style={this.props.style}
-        onKeyDown={this.onInputKeyDown}
-        onChange={this.onChange}
-        onKeyPress={this.props.onKeyPress}
-        onFocus={this.props.onFocus}
-        onBlur={this.props.onBlur}
-        role="combobox"
-        aria-expanded={!this.props.isSuggestsHidden}
-        aria-activedescendant={
-          this.props.activeSuggest
-            ? this.props.activeSuggest.placeId
-            : // eslint-disable-next-line no-undefined
-              undefined
-        }
-        aria-owns={this.props.listId}
-      />
+      <>
+        {shouldRenderLabel && (
+          <label className="geosuggest__label" htmlFor={this.props.id}>
+            {this.props.label}
+          </label>
+        )}
+        <input
+          className={classes}
+          id={`geosuggest__input${this.props.id ? `--${this.props.id}` : ''}`}
+          ref={(i): HTMLInputElement | null => (this.input = i)}
+          type="text"
+          {...attributes}
+          value={this.props.value}
+          style={this.props.style}
+          onKeyDown={this.onInputKeyDown}
+          onChange={this.onChange}
+          onKeyPress={this.props.onKeyPress}
+          onFocus={this.props.onFocus}
+          onBlur={this.props.onBlur}
+          role="combobox"
+          aria-expanded={!this.props.isSuggestsHidden}
+          aria-activedescendant={
+            this.props.activeSuggest
+              ? this.props.activeSuggest.placeId
+              : // eslint-disable-next-line no-undefined
+                undefined
+          }
+          aria-owns={this.props.listId}
+        />
+      </>
     );
   }
 }

--- a/src/types/props.d.ts
+++ b/src/types/props.d.ts
@@ -11,6 +11,7 @@ export default interface IProps {
   readonly initialValue?: string;
   readonly placeholder?: string;
   readonly disabled?: boolean;
+  readonly id?: string;
   readonly className?: string;
   readonly inputClassName?: string;
   readonly suggestsClassName?: string;

--- a/test/Geosuggest_spec.tsx
+++ b/test/Geosuggest_spec.tsx
@@ -1080,5 +1080,26 @@ describe('Component: Geosuggest', () => {
 
       expect(geoSuggestInput.getAttribute('aria-owns')).to.equal(listId);
     });
+
+    it('should have aria-owns attribute set to the list id with the passed in ID', () => {
+      const props = {
+        id: 'test-id'
+      };
+      render(props);
+
+      const input = TestUtils.findRenderedDOMComponentWithClass(
+        component,
+        'geosuggest__input'
+      );
+      const suggests = TestUtils.scryRenderedDOMComponentsWithClass(
+        component,
+        'geosuggest__suggests'
+      );
+
+      const listId = suggests[0].getAttribute('id');
+
+      expect(input.getAttribute('aria-owns')).to.equal(listId);
+      expect(listId?.endsWith(props.id)).to.be.true;
+    });
   });
 });

--- a/test/Geosuggest_spec.tsx
+++ b/test/Geosuggest_spec.tsx
@@ -697,19 +697,20 @@ describe('Component: Geosuggest', () => {
   });
 
   describe('with label and id props', () => {
-    const props = {
-      id: 'geosuggest-id',
-      label: 'some label'
-    };
-
-    beforeEach(() => render(props));
-
     it('should render a <label> if the `label` and `id` props were supplied', () => {
+      const props = {
+        id: 'geosuggest-id',
+        label: 'some label'
+      };
+
+      render(props);
+
       const label = TestUtils.findRenderedDOMComponentWithTag(
         component,
         'label'
       );
-      expect(label).to.not.equal(null);
+
+      expect(label).to.not.be.null;
     });
   });
 
@@ -1100,6 +1101,22 @@ describe('Component: Geosuggest', () => {
 
       expect(input.getAttribute('aria-owns')).to.equal(listId);
       expect(listId?.endsWith(props.id)).to.be.true;
+    });
+
+    it('should have id set to the input according to the passed in ID', () => {
+      const props = {
+        id: 'test-id'
+      };
+      render(props);
+
+      const input = TestUtils.findRenderedDOMComponentWithClass(
+        component,
+        'geosuggest__input'
+      );
+
+      expect(input.getAttribute('id')).to.equal(
+        `geosuggest__input--${props.id}`
+      );
     });
   });
 });


### PR DESCRIPTION
<!-- Please fill out the title field according to our commit conventions -->

### Description

Fixes #452, a bug where the random ID for the suggest list makes snapshot tests and enhancing server side rendered apps unusable.

The random ID was added to make the suggest list readable for screen readers, see commit https://github.com/ubilabs/react-geosuggest/commit/b6b7f3dce4f78dddec6cd1c0a74f29c43cfcd171.

This uses an ID that can get passed in and otherwise uses a default ID. The ID then is added to the input and the list with a prefix. Closes #450, too.

### Checklist

<!-- Mark these as checked by replacing [ ] with [x] -->
- [x] All tests passing
- [x] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
- [x] Commits and PR follow conventions
