### PR TITLE
fix: geocode in selectSuggest when nothing selected

### DIFF
--- a/src/Geosuggest.tsx
+++ b/src/Geosuggest.tsx
@@ -483,6 +483,7 @@ export default class extends React.Component<IProps, IState> {
   // eslint-disable-next-line complexity
   selectSuggest(suggestToSelect: ISuggest | null): void {
     let suggest: ISuggest = suggestToSelect || {
+      // isFixture: true,
       isFixture: false,
       label: this.state.userInput,
       placeId: this.state.userInput

--- a/src/Geosuggest.tsx
+++ b/src/Geosuggest.tsx
@@ -483,8 +483,7 @@ export default class extends React.Component<IProps, IState> {
   // eslint-disable-next-line complexity
   selectSuggest(suggestToSelect: ISuggest | null): void {
     let suggest: ISuggest = suggestToSelect || {
-      // isFixture: true,
-      isFixture: false,
+      isFixture: true,
       label: this.state.userInput,
       placeId: this.state.userInput
     };


### PR DESCRIPTION
<!-- Please fill out the title field according to our commit conventions -->

### Description

Fixes a bug where the geocoding wasn’t triggered when calling `selectSuggest` while nothing is active.

### Checklist

Couldn’t write tests as the API call is involved. Need some mocking for this…

<!-- Mark these as checked by replacing [ ] with [x] -->
- [x] All tests passing
- [ ] Created tests which fail without the change (if possible) 
- [x] Extended the README / documentation, if necessary
- [x] Commits and PR follow conventions
