### PR TITLE
feat(Geosuggest): add option for search input type

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,12 @@ Default: `nope`
 
 Autocomplete input attribute.
 
+#### inputType
+Type: `String`,
+Default: `text`
+
+The value for the `type` attribute on the html input element. Can be either `text` or `search`.
+
 #### Others
 
 All [allowed attributes for `input[type="text"]`](https://github.com/ubilabs/react-geosuggest/blob/master/src/filter-input-attributes.ts#L4)

--- a/src/Geosuggest.tsx
+++ b/src/Geosuggest.tsx
@@ -614,6 +614,7 @@ export default class extends React.Component<IProps, IState> {
         onBlur={this.onInputBlur}
         onKeyDown={this.props.onKeyDown}
         onKeyPress={this.props.onKeyPress}
+        inputType={this.props.inputType}
         onNext={this.onNext}
         onPrev={this.onPrev}
         onSelect={this.onSelect}

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -20,5 +20,6 @@ export default {
   placeholder: 'Search places',
   queryDelay: 250,
   skipSuggest: () => false,
-  style: {}
+  style: {},
+  inputType: 'text'
 };

--- a/src/input.tsx
+++ b/src/input.tsx
@@ -18,6 +18,7 @@ interface IProps {
   readonly activeSuggest: ISuggest | null;
   readonly listId: string;
   readonly label?: string;
+  readonly inputType: string;
   readonly onChange: (value: string) => void;
   readonly onSelect: () => void;
   readonly onKeyDown?: (event: React.KeyboardEvent) => void;
@@ -43,6 +44,7 @@ export default class Input extends React.PureComponent<IProps, {}> {
     className: '',
     isSuggestsHidden: true,
     listId: '',
+    inputType: 'text',
     onBlur: () => {},
     onChange: () => {},
     onEscape: () => {},
@@ -168,7 +170,7 @@ export default class Input extends React.PureComponent<IProps, {}> {
           className={classes}
           id={`geosuggest__input${this.props.id ? `--${this.props.id}` : ''}`}
           ref={(i): HTMLInputElement | null => (this.input = i)}
-          type="text"
+          type={this.props.inputType}
           {...attributes}
           value={this.props.value}
           style={this.props.style}

--- a/src/types/props.d.ts
+++ b/src/types/props.d.ts
@@ -57,4 +57,5 @@ export default interface IProps {
   readonly autoComplete?: string;
   readonly minLength?: number;
   readonly placeDetailFields?: string[] | null;
+  readonly inputType?: string;
 }


### PR DESCRIPTION
# Description

Closes #441

Add an `inputType` prop allowing users to use an html `search` input instead with a default value of `text` 

### Checklist

<!-- Mark these as checked by replacing [ ] with [x] -->
- [x] All tests passing
- [ ] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
- [x] Commits and PR follow conventions
