### PR TITLE
fix(Geosuggest): fix input id and label for

### DIFF
--- a/example/src/app.tsx
+++ b/example/src/app.tsx
@@ -42,6 +42,8 @@ const App = (): JSX.Element => {
 
   return (
     <Geosuggest
+      label="Geoautocomplete"
+      id="geosuggest"
       fixtures={fixtures}
       onFocus={onFocus}
       onBlur={onBlur}

--- a/src/Geosuggest.tsx
+++ b/src/Geosuggest.tsx
@@ -650,7 +650,7 @@ export default class extends React.Component<IProps, IState> {
     );
 
     return (
-      <div className={classes} id={this.props.id}>
+      <div className={classes} id={`${this.props.id}--geosuggest`}>
         <div className="geosuggest__input-wrapper">{input}</div>
         <div className="geosuggest__suggests-wrapper">{suggestionsList}</div>
       </div>

--- a/src/input.tsx
+++ b/src/input.tsx
@@ -168,7 +168,7 @@ export default class Input extends React.PureComponent<IProps, unknown> {
         )}
         <input
           className={classes}
-          id={`geosuggest__input${this.props.id ? `--${this.props.id}` : ''}`}
+          id={this.props.id ? this.props.id : 'geosuggest__input'}
           ref={(i): HTMLInputElement | null => (this.input = i)}
           type={this.props.inputType}
           {...attributes}

--- a/test/Geosuggest_spec.tsx
+++ b/test/Geosuggest_spec.tsx
@@ -712,6 +712,27 @@ describe('Component: Geosuggest', () => {
 
       expect(label).to.not.be.null;
     });
+
+    it('should render a <label> pointing to the input if `label` and `id` props were supplied', () => {
+      const props = {
+        id: 'geosuggest-id',
+        label: 'some label'
+      };
+
+      render(props);
+
+      const label = TestUtils.findRenderedDOMComponentWithTag(
+        component,
+        'label'
+      ).attributes.getNamedItem('for')?.value;
+
+      const input = TestUtils.findRenderedDOMComponentWithTag(
+        component,
+        'input'
+      ).id;
+
+      expect(label).to.be.equal(input);
+    });
   });
 
   describe('without label and id props', () => {
@@ -1114,9 +1135,7 @@ describe('Component: Geosuggest', () => {
         'geosuggest__input'
       );
 
-      expect(input.getAttribute('id')).to.equal(
-        `geosuggest__input--${props.id}`
-      );
+      expect(input.getAttribute('id')).to.equal(props.id);
     });
   });
 });


### PR DESCRIPTION
<!-- Please fill out the title field according to our commit conventions -->

### Description

Fixes
 
https://github.com/ubilabs/react-geosuggest/issues/490

Right now the label and id input do not work as its explained in the documentation and also how one would probably expect (the label "for" attribute would link to the input "id" : 

In the readme section : 

> If the label and a id prop (see "Others") were supplied, a <label> tag with the passed label text will be rendered. The <label> element's for attribute will correctly point to the id of the <input> element.

However what happens currently is this : 

![Screenshot from 2021-10-21 12-04-10](https://user-images.githubusercontent.com/2866604/138265255-faaf9656-830e-46b3-b45f-642223f07376.png)

With this PR the label for and input id will match. a test was also included to insure this stays as expected in the future

![Screenshot from 2021-10-21 12-00-18](https://user-images.githubusercontent.com/2866604/138265366-3c6728de-cb5b-42d9-8d28-c92ff08a1322.png)


### Checklist

<!-- Mark these as checked by replacing [ ] with [x] -->
- [ ] All tests passing
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
- [ ] Commits and PR follow conventions
