### PR TITLE
fix: added a function to set a key based on the index if the placeId is missing

### DIFF
--- a/src/suggest-list.tsx
+++ b/src/suggest-list.tsx
@@ -42,6 +42,14 @@ export default class SuggestList extends React.PureComponent<Props, unknown> {
   }
 
   /**
+   * Generate a unique key for each suggestion
+   */
+  getSuggestionKey(suggest: Suggest, index: number): string {
+    // Use placeId if available, otherwise fall back to combination of label and index
+    return suggest.placeId || `${suggest.label}_${index}`;
+  }
+
+  /**
    * There are new properties available for the list
    */
   componentDidUpdate(prevProps: Props): void {
@@ -75,7 +83,7 @@ export default class SuggestList extends React.PureComponent<Props, unknown> {
         role="listbox"
         aria-label={this.props.listLabel}
         id={this.props.listId}>
-        {this.props.suggests.map((suggest) => {
+        {this.props.suggests.map((suggest, index) => {
           const isActive =
             (this.props.activeSuggest &&
               suggest.placeId === this.props.activeSuggest.placeId) ||
@@ -83,7 +91,7 @@ export default class SuggestList extends React.PureComponent<Props, unknown> {
 
           return (
             <SuggestItem
-              key={suggest.placeId}
+              key={this.getSuggestionKey(suggest, index)}
               className={suggest.className || ''}
               userInput={this.props.userInput}
               isHighlightMatch={this.props.isHighlightMatch}


### PR DESCRIPTION
<!-- Please fill out the title field according to our commit conventions -->

### Description

Fixes a bug where the error "Each child in a list should have a unique "key" prop" was logged to the console on the first character typed.

### Checklist

<!-- Mark these as checked by replacing [ ] with [x] -->
- [x] All tests passing
- [ ] Created tests which fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
- [x] Commits and PR follow conventions
