### PR TITLE
fix(geosuggest): Add a key for the returned <li> in suggest-item

### DIFF
--- a/src/suggest-item.tsx
+++ b/src/suggest-item.tsx
@@ -153,6 +153,7 @@ export default class SuggestItem extends React.PureComponent<Props, unknown> {
 
     return (
       <li
+        key={`suggest-item-${suggest.placeId}`}
         className={classes}
         ref={(li: HTMLLIElement | null) => {
           this.ref = li;


### PR DESCRIPTION
### Description

Fixes #515 by adding a `key` to the returned `<li>` from `suggest-item`. 

This puts a `key` field in both the JSX element `SuggestItem` as well the returned `li`. I don't think there's a downside to having more keys, and this resolves the crashes I was seeing and that were reported in the linked issue. 

### Checklist
- [ ] All tests passing
- [ ] Created tests which fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
- [ ] Commits and PR follow conventions
